### PR TITLE
Connect auth landing page to event dashboard and fix some styling

### DIFF
--- a/src/components/HomeLandingPage/AddEventButton.tsx
+++ b/src/components/HomeLandingPage/AddEventButton.tsx
@@ -9,7 +9,8 @@ type AddEventButton = () => JSX.Element;
 const useEventButtonStyles = makeStyles({
   root: {
     borderRadius: '3rem',
-    minWidth: '15rem',
+    minWidth: '228px',
+    minHeight: '48px',
   },
 });
 
@@ -20,7 +21,7 @@ const AddEventButton: AddEventButton = () => {
       component={NavLink}
       to="/events/new"
       variant="contained"
-      color="primary"
+      color="secondary"
       startIcon={<AddIcon />}
       classes={{
         root: classes.root,

--- a/src/components/HomeLandingPage/CardOptions.tsx
+++ b/src/components/HomeLandingPage/CardOptions.tsx
@@ -19,6 +19,7 @@ const CardOptions: CardOptions = () => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
     setAnchorEl(event.currentTarget);
   };
 

--- a/src/components/HomeLandingPage/EventCard.tsx
+++ b/src/components/HomeLandingPage/EventCard.tsx
@@ -10,6 +10,7 @@ interface EventCardProps {
   date: Date;
   eventTitle: string;
   address: string;
+  handleClick: () => void;
 }
 
 type EventCard = ({ date, eventTitle, address }: EventCardProps) => JSX.Element;
@@ -20,6 +21,7 @@ const useEventCardStyles = makeStyles({
     boxShadow: 'none',
     width: '20rem',
     height: '10rem',
+    cursor: 'pointer',
   },
   cardContent: {
     padding: '2em 2em',
@@ -35,10 +37,11 @@ const EventCard: EventCard = ({
   date,
   eventTitle,
   address,
+  handleClick,
 }: EventCardProps) => {
   const classes = useEventCardStyles();
   return (
-    <Card className={classes.root}>
+    <Card className={classes.root} onClick={handleClick}>
       <CardContent className={classes.cardContent}>
         <Box display="flex">
           <Typography color="textSecondary">{date}</Typography>

--- a/src/components/HomeLandingPage/HomeLandingPage.tsx
+++ b/src/components/HomeLandingPage/HomeLandingPage.tsx
@@ -4,12 +4,13 @@ import Typography from '@material-ui/core/Typography';
 import Grid from '@material-ui/core/Grid';
 import AccountCircleIcon from '@material-ui/icons/AccountCircle';
 
-import MenuTabs from '../components/common/MenuTabs';
-import AddEventButton from '../components/HomeLandingPage/AddEventButton';
-import EventCard from '../components/HomeLandingPage/EventCard';
-import useAllEvents from '../graphql/queries/hooks/events';
-import { EventType, GET_ALL_EVENTS } from '../graphql/queries/events';
-import '../styles/HomeLandingPage.css';
+import MenuTabs from '../common/MenuTabs';
+import AddEventButton from './AddEventButton';
+import EventCard from './EventCard';
+import useAllEvents from '../../graphql/queries/hooks/events';
+import { EventType, GET_ALL_EVENTS } from '../../graphql/queries/events';
+import '../../styles/HomeLandingPage.css';
+import { useHistory } from 'react-router-dom';
 
 const HomeLandingPage = () => {
   const [selectedTab, setTab] = useState(0);
@@ -19,6 +20,7 @@ const HomeLandingPage = () => {
   ) => {
     setTab(newValue);
   };
+  const history = useHistory();
 
   const tabLabels = ['Current Events', 'Archived Events'];
 
@@ -28,6 +30,7 @@ const HomeLandingPage = () => {
   // Fetch events from cache
   const { data } = useQuery(GET_ALL_EVENTS);
   const events: Array<EventType> = data ? data.events : [];
+  console.log(events);
 
   return (
     <div className="landing-wrapper">
@@ -60,6 +63,7 @@ const HomeLandingPage = () => {
                 date={event.eventDate}
                 eventTitle={event.name}
                 address="N/A"
+                handleClick={() => history.push(`/events/${event.id}`)}
               />
             </Grid>
           ))}

--- a/src/components/HomeLandingPage/HomeLandingPage.tsx
+++ b/src/components/HomeLandingPage/HomeLandingPage.tsx
@@ -57,9 +57,9 @@ const HomeLandingPage = () => {
       <div className="landing-body">
         <Grid container direction="row" alignItems="center" spacing={3}>
           {events.map((event: EventType) => (
-            <Grid item key={event.name}>
+            <Grid item key={event.id}>
               <EventCard
-                key={event.name}
+                key={event.id}
                 date={event.eventDate}
                 eventTitle={event.name}
                 address="N/A"

--- a/src/components/HomeLandingPage/HomeLandingPage.tsx
+++ b/src/components/HomeLandingPage/HomeLandingPage.tsx
@@ -4,13 +4,13 @@ import Typography from '@material-ui/core/Typography';
 import Grid from '@material-ui/core/Grid';
 import AccountCircleIcon from '@material-ui/icons/AccountCircle';
 
+import { useHistory } from 'react-router-dom';
 import MenuTabs from '../common/MenuTabs';
 import AddEventButton from './AddEventButton';
 import EventCard from './EventCard';
 import useAllEvents from '../../graphql/queries/hooks/events';
 import { EventType, GET_ALL_EVENTS } from '../../graphql/queries/events';
 import '../../styles/HomeLandingPage.css';
-import { useHistory } from 'react-router-dom';
 
 const HomeLandingPage = () => {
   const [selectedTab, setTab] = useState(0);
@@ -30,7 +30,6 @@ const HomeLandingPage = () => {
   // Fetch events from cache
   const { data } = useQuery(GET_ALL_EVENTS);
   const events: Array<EventType> = data ? data.events : [];
-  console.log(events);
 
   return (
     <div className="landing-wrapper">

--- a/src/components/HomeLandingPage/HomeLandingPage.tsx
+++ b/src/components/HomeLandingPage/HomeLandingPage.tsx
@@ -45,7 +45,7 @@ const HomeLandingPage = () => {
             >
               Joe Li
             </Typography>
-            <AccountCircleIcon fontSize="large" color="primary" />
+            <AccountCircleIcon fontSize="large" color="secondary" />
           </div>
         </div>
         <MenuTabs

--- a/src/components/ScanPatientPage/ScanPatientTopBar.tsx
+++ b/src/components/ScanPatientPage/ScanPatientTopBar.tsx
@@ -8,7 +8,6 @@ import Button from '@material-ui/core/Button';
 import IconButton from '@material-ui/core/IconButton';
 import { makeStyles, createStyles } from '@material-ui/core';
 import ArrowBackIcon from '@material-ui/icons/ArrowBack';
-import Quagga from 'quagga';
 import { Colours } from '../../styles/Constants';
 
 const useScanPatientTopBarStyles = makeStyles(() =>

--- a/src/components/common/MenuTabs.tsx
+++ b/src/components/common/MenuTabs.tsx
@@ -41,7 +41,7 @@ const MenuTabs: React.FC<{
     <Tabs
       value={currentTab}
       indicatorColor="secondary"
-      textColor="inherit"
+      textColor="secondary"
       onChange={handleChange}
       classes={{ root: classes.root, indicator: classes.indicator }}
     >

--- a/src/components/common/MenuTabs.tsx
+++ b/src/components/common/MenuTabs.tsx
@@ -16,7 +16,6 @@ const useTabStyles = makeStyles({
     maxWidth: '15rem',
   },
   indicator: {
-    backgroundColor: '#000000',
     height: '0.3rem',
   },
   tabTextColor: {
@@ -41,7 +40,7 @@ const MenuTabs: React.FC<{
   return (
     <Tabs
       value={currentTab}
-      indicatorColor="primary"
+      indicatorColor="secondary"
       textColor="inherit"
       onChange={handleChange}
       classes={{ root: classes.root, indicator: classes.indicator }}

--- a/src/containers/App.tsx
+++ b/src/containers/App.tsx
@@ -3,7 +3,7 @@ import { Switch, Route, Redirect } from 'react-router-dom';
 
 import { ThemeProvider } from '@material-ui/core/styles';
 import { Theme } from '../styles/Theme';
-import HomeLandingPage from './HomeLandingPage';
+import HomeLandingPage from '../components/HomeLandingPage/HomeLandingPage';
 import EventCreationPage from './EventCreationPage';
 import ScanPatientPage from '../components/ScanPatientPage/ScanPatientPage';
 import EnterBarcodePage from '../components/EnterBarcodePage/EnterBarcodePage';

--- a/src/graphql/queries/events.ts
+++ b/src/graphql/queries/events.ts
@@ -1,6 +1,7 @@
 import gql from 'graphql-tag';
 
 export interface EventType {
+  id: string;
   name: string;
   eventDate: Date;
 }
@@ -8,6 +9,7 @@ export interface EventType {
 export const FETCH_ALL_EVENTS = gql`
   query {
     events {
+      id
       name
       eventDate
     }
@@ -17,6 +19,7 @@ export const FETCH_ALL_EVENTS = gql`
 export const GET_ALL_EVENTS = gql`
   query {
     events @client {
+      id
       name
       eventDate
     }

--- a/src/styles/HomeLandingPage.css
+++ b/src/styles/HomeLandingPage.css
@@ -13,7 +13,7 @@
   background-color: white;
 }
 .landing-body {
-  padding: 3em 3em 0em 3em;
+  padding: 70px 56px 168px 56px;
 }
 
 .user-icon {


### PR DESCRIPTION
## Overview
>[Code review doc for reference](https://www.notion.so/uwblueprintexecs/Code-Review-a21fc85b00394f488e92d9d605f6b2bc)

[Notion task](https://www.notion.so/uwblueprintexecs/9224caeb21ce4350b8a1dc378d393323?v=43f44ac04d734394b7f7edc636c523b4)


## Changes
- Fixed styling for the auth landing page
- Clicking on an event card now redirects to the event dashboard

## Testing
- Click on an event card, and verify that it's redirecting to the correct URL

Note: the event dashboard isn't in this PR yet, so clicking on an event card won't actually change your screen
Note2: there's a small styling bug in this PR. The Add New Event button can cover an event card if there's enough of them. This should be fixed in a future PR.

## Screenshots
Landing Page
![image](https://user-images.githubusercontent.com/28452372/89114421-1ac4e080-d44a-11ea-8ec5-98a6b063f6ac.png)



