### PR TITLE
Highlight new added event

### DIFF
--- a/src/components/HomeLandingPage/EventCard.tsx
+++ b/src/components/HomeLandingPage/EventCard.tsx
@@ -1,30 +1,42 @@
 import React from 'react';
+import clsx from 'clsx';
 import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';
 import Typography from '@material-ui/core/Typography';
 import Box from '@material-ui/core/Box';
 import { makeStyles } from '@material-ui/core/styles';
 import CardOptions from './CardOptions';
+import { Colours } from '../../styles/Constants';
 
 interface EventCardProps {
   date: Date;
   eventTitle: string;
+  isNew: boolean;
   address: string;
   handleClick: () => void;
 }
 
-type EventCard = ({ date, eventTitle, address }: EventCardProps) => JSX.Element;
+type EventCard = ({
+  date,
+  eventTitle,
+  isNew,
+  address,
+}: EventCardProps) => JSX.Element;
 
 const useEventCardStyles = makeStyles({
   root: {
     display: 'inline-block',
     boxShadow: 'none',
-    width: '20rem',
-    height: '10rem',
+    width: '339px',
+    height: '161px',
     cursor: 'pointer',
+    border: `1px solid ${Colours.BorderLightGray}`,
+  },
+  highlighted: {
+    backgroundColor: Colours.Blue,
   },
   cardContent: {
-    padding: '2em 2em',
+    padding: '24px 32px',
   },
   eventTitle: {
     whiteSpace: 'nowrap',
@@ -36,21 +48,26 @@ const useEventCardStyles = makeStyles({
 const EventCard: EventCard = ({
   date,
   eventTitle,
+  isNew,
   address,
   handleClick,
 }: EventCardProps) => {
   const classes = useEventCardStyles();
   return (
-    <Card className={classes.root} onClick={handleClick}>
+    <Card
+      className={clsx({
+        [classes.root]: true,
+        [classes.highlighted]: isNew,
+      })}
+      onClick={handleClick}
+    >
       <CardContent className={classes.cardContent}>
         <Box display="flex">
           <Typography color="textSecondary">{date}</Typography>
-
           <Box ml="auto">
             <CardOptions />
           </Box>
         </Box>
-
         <Typography
           color="textPrimary"
           variant="h4"

--- a/src/components/HomeLandingPage/HomeLandingPage.tsx
+++ b/src/components/HomeLandingPage/HomeLandingPage.tsx
@@ -15,7 +15,7 @@ type LocationState = { addedEventId: string | null };
 const HomeLandingPage = () => {
   const history = useHistory();
   const location = useLocation<LocationState>();
-  const { addedEventId } = location.state || { addEventId: null };
+  const { addedEventId } = location.state || { addedEventId: null };
   const [selectedTab, setTab] = useState(0);
 
   // Clear the addedEventId in location state now that it's been used

--- a/src/components/HomeLandingPage/HomeLandingPage.tsx
+++ b/src/components/HomeLandingPage/HomeLandingPage.tsx
@@ -3,8 +3,7 @@ import { useQuery } from 'react-apollo';
 import Typography from '@material-ui/core/Typography';
 import Grid from '@material-ui/core/Grid';
 import AccountCircleIcon from '@material-ui/icons/AccountCircle';
-
-import { useHistory } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 import MenuTabs from '../common/MenuTabs';
 import AddEventButton from './AddEventButton';
 import EventCard from './EventCard';
@@ -12,7 +11,12 @@ import useAllEvents from '../../graphql/queries/hooks/events';
 import { Event, GET_ALL_EVENTS } from '../../graphql/queries/events';
 import '../../styles/HomeLandingPage.css';
 
+type LocationState = { addedEventId: string | null };
+
 const HomeLandingPage = () => {
+  const history = useHistory();
+  const location = useLocation<LocationState>();
+  const { addedEventId } = location.state || { addEventId: null };
   const [selectedTab, setTab] = useState(0);
   const handleChange = (
     event: React.ChangeEvent<unknown>,
@@ -20,7 +24,6 @@ const HomeLandingPage = () => {
   ) => {
     setTab(newValue);
   };
-  const history = useHistory();
 
   const tabLabels = ['Current Events', 'Archived Events'];
 

--- a/src/components/HomeLandingPage/HomeLandingPage.tsx
+++ b/src/components/HomeLandingPage/HomeLandingPage.tsx
@@ -1,7 +1,6 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useQuery } from 'react-apollo';
-import Typography from '@material-ui/core/Typography';
-import Grid from '@material-ui/core/Grid';
+import { Grid, Typography } from '@material-ui/core';
 import AccountCircleIcon from '@material-ui/icons/AccountCircle';
 import { useHistory, useLocation } from 'react-router-dom';
 import MenuTabs from '../common/MenuTabs';
@@ -18,6 +17,16 @@ const HomeLandingPage = () => {
   const location = useLocation<LocationState>();
   const { addedEventId } = location.state || { addEventId: null };
   const [selectedTab, setTab] = useState(0);
+
+  // Clear the addedEventId in location state now that it's been used
+  window.history.pushState(
+    {
+      ...location.state,
+      addEventId: null,
+    },
+    ''
+  );
+
   const handleChange = (
     event: React.ChangeEvent<unknown>,
     newValue: number
@@ -64,6 +73,7 @@ const HomeLandingPage = () => {
                 key={event.id}
                 date={event.eventDate}
                 eventTitle={event.name}
+                isNew={event.id === addedEventId}
                 address="N/A"
                 handleClick={() => history.push(`/events/${event.id}`)}
               />

--- a/src/components/HomeLandingPage/HomeLandingPage.tsx
+++ b/src/components/HomeLandingPage/HomeLandingPage.tsx
@@ -22,7 +22,7 @@ const HomeLandingPage = () => {
   window.history.pushState(
     {
       ...location.state,
-      addEventId: null,
+      addedEventId: null,
     },
     ''
   );

--- a/src/components/HomeLandingPage/HomeLandingPage.tsx
+++ b/src/components/HomeLandingPage/HomeLandingPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useQuery } from 'react-apollo';
 import { Grid, Typography } from '@material-ui/core';
 import AccountCircleIcon from '@material-ui/icons/AccountCircle';

--- a/src/containers/EventCreationPage.tsx
+++ b/src/containers/EventCreationPage.tsx
@@ -28,6 +28,12 @@ const EventCreationPage = () => {
         data: { events: events.concat([addEvent]) },
       });
     },
+    onCompleted(data) {
+      history.replace('/events', { addedEventId: data.id });
+    },
+    onError() {
+      history.replace('/events');
+    },
   });
 
   const [openCancelModal, setOpenHandleModal] = useState(false);
@@ -97,7 +103,6 @@ const EventCreationPage = () => {
         isActive: true,
       },
     });
-    history.replace('/events');
   };
 
   const content =

--- a/src/containers/EventCreationPage.tsx
+++ b/src/containers/EventCreationPage.tsx
@@ -28,8 +28,8 @@ const EventCreationPage = () => {
         data: { events: events.concat([addEvent]) },
       });
     },
-    onCompleted(data) {
-      history.replace('/events', { addedEventId: data.id });
+    onCompleted({ addEvent }) {
+      history.replace('/events', { addedEventId: addEvent.id });
     },
     onError() {
       history.replace('/events');

--- a/src/graphql/mutations/events.ts
+++ b/src/graphql/mutations/events.ts
@@ -13,6 +13,7 @@ export const ADD_EVENT = gql`
       createdBy: $createdBy
       isActive: $isActive
     ) {
+      id
       name
       eventDate
     }


### PR DESCRIPTION
## Overview
>[Code review doc for reference](https://www.notion.so/uwblueprintexecs/Code-Review-a21fc85b00394f488e92d9d605f6b2bc)

[Notion task](https://www.notion.so/uwblueprintexecs/on-entity-create-event-snackbar-4b64273fa7aa423d8504aada96547f28)


## Changes
- Highlight event card of newly added event

## Testing
- Add a new event from `/events`
- After clicking "Create" at the end of the form, it should redirect you to `/events` and the event card for the event that was added should have a blue background instead of white 
- Also try refreshing the page and navigating away from `/events` and confirm that the event card is no longer blue

## Screenshots
![image](https://user-images.githubusercontent.com/22457859/90353635-b3e02380-e014-11ea-99ce-12954a869a40.png)
