### PR TITLE
Fix bug where CCP dashboard shows no patients

### DIFF
--- a/src/graphql/queries/patients.ts
+++ b/src/graphql/queries/patients.ts
@@ -46,6 +46,7 @@ export const GET_PATIENT_BY_ID = (id: string) => {
           id
           name
           eventId {
+            id
             name
             eventDate
           }
@@ -76,6 +77,7 @@ export const FETCH_ALL_PATIENTS = gql`
         id
         name
         eventId {
+          id
           name
           eventDate
         }
@@ -104,6 +106,7 @@ export const GET_ALL_PATIENTS = gql`
         id
         name
         eventId {
+          id
           name
           eventDate
         }


### PR DESCRIPTION
## Overview
>[Code review doc for reference](https://www.notion.so/uwblueprintexecs/Code-Review-a21fc85b00394f488e92d9d605f6b2bc)

[Notion task](https://www.notion.so/uwblueprintexecs/396370c5e09f4c28bc7f455a7e84c908?v=3751aa62a2594c74b7e0ecb363304c24&p=d7b2b30ca27040b58fe410e7919b6655)


## Changes
- Added ID as returned field from patient queries

## Testing
- Navigate from event dashboard to CCP dashboard
- Confirm that patients correctly appear on the CCP dashboard

## Screenshots
Prior to fixing, we'd get an error from this flow:

1. From the event dashboard, navigate to a CCP dashboard
![image](https://user-images.githubusercontent.com/28452372/90985444-0dcb7680-e54a-11ea-9d38-82bcc004f663.png)

2. No patients show, even when they exist
![image](https://user-images.githubusercontent.com/28452372/90985458-22a80a00-e54a-11ea-9ebd-0676df99aa56.png)


Now, after fixing, the patients show correctly:
![image](https://user-images.githubusercontent.com/28452372/90985470-32bfe980-e54a-11ea-9277-ad1156da81a1.png)

