### PR TITLE
Event dashboard cleanup

### DIFF
--- a/src/components/EventDashboard/ResourceTabPanel.tsx
+++ b/src/components/EventDashboard/ResourceTabPanel.tsx
@@ -68,14 +68,6 @@ const useStyles = makeStyles({
   toolbar: {
     padding: '0 0 0 4px',
   },
-  addButton: {
-    boxShadow: '0px 4px 10px rgba(0, 0, 0, 0.3)',
-    borderRadius: '2000px',
-    position: 'fixed',
-    bottom: '56px',
-    right: '56px',
-    padding: '12px 26px',
-  },
   buttonCell: {
     paddingTop: 0,
     paddingBottom: 0,
@@ -484,14 +476,6 @@ const ResourceTabPanel = ({
           <TableBody>{tableRows}</TableBody>
         </Table>
       </TableContainer>
-      <Button
-        className={classes.addButton}
-        variant="contained"
-        color="secondary"
-      >
-        <Add className={classes.buttonIcon} />
-        {`Add ${type === TabOptions.Hospital ? 'Hospital' : 'Ambulance'}`}
-      </Button>
       <ActionConfirmationDialog
         open={open}
         type={type}

--- a/src/components/common/MenuAppBar.tsx
+++ b/src/components/common/MenuAppBar.tsx
@@ -6,6 +6,7 @@ import {
   Typography,
   IconButton,
   Drawer,
+  Link,
   List,
   ListItem,
   ListItemIcon,
@@ -15,7 +16,7 @@ import {
 import MenuIcon from '@material-ui/icons/Menu';
 import RoomOutlinedIcon from '@material-ui/icons/RoomOutlined';
 import { useQuery } from '@apollo/react-hooks';
-import { useHistory } from 'react-router-dom';
+import { NavLink, useHistory } from 'react-router-dom';
 import { ScanIcon } from './ScanIcon';
 import { GET_CCPS_BY_EVENT_ID } from '../../graphql/queries/ccps';
 import { GET_EVENT_BY_ID } from '../../graphql/queries/events';
@@ -34,6 +35,7 @@ const useStyles = makeStyles({
     flexGrow: 1,
   },
   list: {
+    height: '100%',
     width: '250px',
   },
   fullList: {
@@ -45,8 +47,10 @@ const useStyles = makeStyles({
   active: {
     backgroundColor: 'red',
   },
-  link: {
-    textDecoration: 'none',
+  viewEventsLink: {
+    position: 'absolute',
+    bottom: 0,
+    padding: '24px',
   },
 });
 
@@ -138,6 +142,15 @@ export default function MenuAppBar(props: MenuAppBarProps) {
               </ListItem>
             ))}
           </List>
+          <Link
+            color="secondary"
+            variant="body2"
+            component={NavLink}
+            to="/events"
+            className={classes.viewEventsLink}
+          >
+            View other events
+          </Link>
         </div>
       </Drawer>
     </>


### PR DESCRIPTION
## Overview
>[Code review doc for reference](https://www.notion.so/uwblueprintexecs/Code-Review-a21fc85b00394f488e92d9d605f6b2bc)

[Notion task 1](https://www.notion.so/uwblueprintexecs/view-other-events-in-side-menu-d107562ab26349a3a0cad18b0499a1fc)
[Notion task 2](https://www.notion.so/uwblueprintexecs/add-resources-buttons-f961c2e1edb3471a8fa4f633c490cfb3)


## Changes
- Add "View other events" link in drawer
- Remove "Add Hospital" and "Add Ambulance" buttons on Event Dashboard

## Testing
- Go to event dashboard for any event (at `/events/{eventId}`)
1. Click the hamburger menu to open the drawer, and verify the "View other events" link navigates to the `/events` landing page

![image](https://user-images.githubusercontent.com/22457859/90987529-ab7a7200-e559-11ea-935a-9b1608e24724.png)

2. On the event dashboard, click the "Hospital" and "Ambulance" tabs to verify the "Add" buttons have been removed

<img width="1280" alt="Screen Shot 2020-08-23 at 3 54 32 PM" src="https://user-images.githubusercontent.com/22457859/90987519-969dde80-e559-11ea-9ee4-f67963f9c971.png">
<img width="1280" alt="Screen Shot 2020-08-23 at 3 54 39 PM" src="https://user-images.githubusercontent.com/22457859/90987526-a1f10a00-e559-11ea-852d-729bcda18bc5.png">

