### PR TITLE
Handle "Enter" key in manual barcode

### DIFF
--- a/src/components/EnterBarcode/CompleteBarcodeButton.tsx
+++ b/src/components/EnterBarcode/CompleteBarcodeButton.tsx
@@ -13,8 +13,10 @@ const useCompleteBarcodeButtonStyles = makeStyles({
 
 const CompleteBarcodeButton = ({
   handleClick,
+  isEmpty,
 }: {
   handleClick: () => any | null;
+  isEmpty: boolean;
 }) => {
   const classes = useCompleteBarcodeButtonStyles();
   return (
@@ -26,6 +28,7 @@ const CompleteBarcodeButton = ({
       }}
       type="submit"
       onClick={handleClick}
+      disabled={isEmpty}
     >
       Next
     </Button>

--- a/src/components/EnterBarcode/EnterBarcodePage.tsx
+++ b/src/components/EnterBarcode/EnterBarcodePage.tsx
@@ -49,6 +49,10 @@ const EnterBarcodePage = ({
     }
   };
 
+  const handleFormSubmit = (e) => {
+    return barcode !== '' ? handleEnterBarcode() : e.preventDefault();
+  };
+
   return (
     <Box minHeight="100vh">
       <Box
@@ -67,11 +71,7 @@ const EnterBarcodePage = ({
         </Button>
       </Box>
       <Box padding="56px">
-        <form
-          onSubmit={(e) =>
-            barcode !== '' ? handleEnterBarcode() : e.preventDefault()
-          }
-        >
+        <form onSubmit={handleFormSubmit}>
           <FormField
             label="Barcode:"
             placeholder="Enter barcode here"

--- a/src/components/EnterBarcode/EnterBarcodePage.tsx
+++ b/src/components/EnterBarcode/EnterBarcodePage.tsx
@@ -21,35 +21,31 @@ const EnterBarcodePage = ({
   const [barcode, setBarcode] = useState<string>('');
 
   const handleEnterBarcode = () => {
-    if (barcode !== '') {
-      if (!loading && data) {
-        const selectedPatient = data.patients.filter(
-          (patient) => patient.barcodeValue === barcode
+    if (!loading && data) {
+      const selectedPatient = data.patients.filter(
+        (patient) => patient.barcodeValue === barcode
+      );
+      if (selectedPatient.length > 0) {
+        // Found patient
+        const {
+          collectionPointId: {
+            id: patientCcpId,
+            eventId: { id: patientEventId },
+          },
+          id,
+        } = selectedPatient[0];
+        // Redirect to patient profile
+        history.push(
+          `/events/${patientEventId}/ccps/${patientCcpId}/patients/${id}`
         );
-        if (selectedPatient.length > 0) {
-          // Found patient
-          const {
-            collectionPointId: {
-              id: patientCcpId,
-              eventId: { id: patientEventId },
-            },
-            id,
-          } = selectedPatient[0];
-          // Redirect to patient profile
-          history.push(
-            `/events/${patientEventId}/ccps/${patientCcpId}/patients/${id}`
-          );
-        } else {
-          // No existing patient
-          history.push(
-            `/events/${eventId}/ccps/${ccpId}/patients/new/${barcode}`
-          );
-        }
       } else {
+        // No existing patient
         history.push(
           `/events/${eventId}/ccps/${ccpId}/patients/new/${barcode}`
         );
       }
+    } else {
+      history.push(`/events/${eventId}/ccps/${ccpId}/patients/new/${barcode}`);
     }
   };
 
@@ -71,7 +67,11 @@ const EnterBarcodePage = ({
         </Button>
       </Box>
       <Box padding="56px">
-        <form onSubmit={handleEnterBarcode}>
+        <form
+          onSubmit={(e) =>
+            barcode !== '' ? handleEnterBarcode() : e.preventDefault()
+          }
+        >
           <FormField
             label="Barcode:"
             placeholder="Enter barcode here"

--- a/src/components/EnterBarcode/EnterBarcodePage.tsx
+++ b/src/components/EnterBarcode/EnterBarcodePage.tsx
@@ -77,7 +77,10 @@ const EnterBarcodePage = ({
           />
         </form>
       </Box>
-      <CompleteBarcodeButton handleClick={handleEnterBarcode} />
+      <CompleteBarcodeButton
+        handleClick={handleEnterBarcode}
+        isEmpty={barcode === ''}
+      />
     </Box>
   );
 };

--- a/src/components/EnterBarcode/EnterBarcodePage.tsx
+++ b/src/components/EnterBarcode/EnterBarcodePage.tsx
@@ -72,6 +72,7 @@ const EnterBarcodePage = ({
             label="Barcode:"
             placeholder="Enter barcode here"
             onChange={(e: any) => setBarcode(e.target.value)}
+            onKeyPress={(e: any) => e.key === 'Enter' && handleEnterBarcode()}
             value={barcode}
             isValidated={false}
           />

--- a/src/components/EnterBarcode/EnterBarcodePage.tsx
+++ b/src/components/EnterBarcode/EnterBarcodePage.tsx
@@ -67,12 +67,11 @@ const EnterBarcodePage = ({
         </Button>
       </Box>
       <Box padding="56px">
-        <form>
+        <form onSubmit={handleEnterBarcode}>
           <FormField
             label="Barcode:"
             placeholder="Enter barcode here"
             onChange={(e: any) => setBarcode(e.target.value)}
-            onKeyPress={(e: any) => e.key === 'Enter' && handleEnterBarcode()}
             value={barcode}
             isValidated={false}
           />

--- a/src/components/EnterBarcode/EnterBarcodePage.tsx
+++ b/src/components/EnterBarcode/EnterBarcodePage.tsx
@@ -21,31 +21,35 @@ const EnterBarcodePage = ({
   const [barcode, setBarcode] = useState<string>('');
 
   const handleEnterBarcode = () => {
-    if (!loading && data) {
-      const selectedPatient = data.patients.filter(
-        (patient) => patient.barcodeValue === barcode
-      );
-      if (selectedPatient.length > 0) {
-        // Found patient
-        const {
-          collectionPointId: {
-            id: patientCcpId,
-            eventId: { id: patientEventId },
-          },
-          id,
-        } = selectedPatient[0];
-        // Redirect to patient profile
-        history.push(
-          `/events/${patientEventId}/ccps/${patientCcpId}/patients/${id}`
+    if (barcode !== '') {
+      if (!loading && data) {
+        const selectedPatient = data.patients.filter(
+          (patient) => patient.barcodeValue === barcode
         );
+        if (selectedPatient.length > 0) {
+          // Found patient
+          const {
+            collectionPointId: {
+              id: patientCcpId,
+              eventId: { id: patientEventId },
+            },
+            id,
+          } = selectedPatient[0];
+          // Redirect to patient profile
+          history.push(
+            `/events/${patientEventId}/ccps/${patientCcpId}/patients/${id}`
+          );
+        } else {
+          // No existing patient
+          history.push(
+            `/events/${eventId}/ccps/${ccpId}/patients/new/${barcode}`
+          );
+        }
       } else {
-        // No existing patient
         history.push(
           `/events/${eventId}/ccps/${ccpId}/patients/new/${barcode}`
         );
       }
-    } else {
-      history.push(`/events/${eventId}/ccps/${ccpId}/patients/new/${barcode}`);
     }
   };
 

--- a/src/components/common/FormField.tsx
+++ b/src/components/common/FormField.tsx
@@ -39,6 +39,7 @@ const FormField: React.FC<{
   label: string;
   placeholder?: string;
   onChange?: (e: React.ChangeEvent<HTMLElement>) => void;
+  onKeyPress?: (e: React.KeyboardEvent<HTMLDivElement>) => void;
   value: string;
   handleFocus?: () => void;
   isValidated: boolean;
@@ -49,6 +50,7 @@ const FormField: React.FC<{
   label,
   placeholder,
   onChange,
+  onKeyPress,
   value,
   handleFocus,
   isValidated,
@@ -59,6 +61,7 @@ const FormField: React.FC<{
   label: string;
   placeholder?: string;
   onChange?: (e: React.ChangeEvent<HTMLElement>) => void;
+  onKeyPress?: (e: React.KeyboardEvent<HTMLDivElement>) => void;
   value: string | number | null;
   handleFocus?: () => void;
   isValidated: boolean;
@@ -98,6 +101,7 @@ const FormField: React.FC<{
       className={classes.root}
       margin="normal"
       onChange={onChange}
+      onKeyPress={onKeyPress}
       value={value}
       onFocus={handleFocus}
     />

--- a/src/components/common/FormField.tsx
+++ b/src/components/common/FormField.tsx
@@ -39,7 +39,6 @@ const FormField: React.FC<{
   label: string;
   placeholder?: string;
   onChange?: (e: React.ChangeEvent<HTMLElement>) => void;
-  onKeyPress?: (e: React.KeyboardEvent<HTMLDivElement>) => void;
   value: string;
   handleFocus?: () => void;
   isValidated: boolean;
@@ -50,7 +49,6 @@ const FormField: React.FC<{
   label,
   placeholder,
   onChange,
-  onKeyPress,
   value,
   handleFocus,
   isValidated,
@@ -61,7 +59,6 @@ const FormField: React.FC<{
   label: string;
   placeholder?: string;
   onChange?: (e: React.ChangeEvent<HTMLElement>) => void;
-  onKeyPress?: (e: React.KeyboardEvent<HTMLDivElement>) => void;
   value: string | number | null;
   handleFocus?: () => void;
   isValidated: boolean;
@@ -101,7 +98,6 @@ const FormField: React.FC<{
       className={classes.root}
       margin="normal"
       onChange={onChange}
-      onKeyPress={onKeyPress}
       value={value}
       onFocus={handleFocus}
     />


### PR DESCRIPTION
[Notion ticket](https://www.notion.so/uwblueprintexecs/Enter-Barcode-Page-pressing-the-Enter-key-does-not-pass-input-6c7eacc467fe4d73915e497ae63189d2)

## Changes
- ~~Updated `FormField.tsx` with a new `onKeyPress` prop~~
- ~~Reason for prop is because `TextField`, the component used in `FormField.tsx`, doesn't seem to have this as a prop~~ 
- ~~Additionally, onChange does not handle `React.KeyboardEvent`~~
- ~~On "Enter" key press, directs the user to the next step of the flow~~
- **After CR suggestions**
    - Use `onSubmit` to handle "Enter" key
## Testing
- Type in a barcode manually and press the "Enter" key on your keyboard
- This should redirect you to the next barcode page with your input from the previous page in the barcode field 
- If there was no input, you will stay on the same page

## Checklist
>[Code review doc for reference](https://www.notion.so/uwblueprintexecs/Code-Review-a21fc85b00394f488e92d9d605f6b2bc)

before opening PR
- [x] check notion ticket
- [x] run linter
- [x] go through file diff

filling out PR
- [x] descriptive title
- [x] update `notion ticket` link
- [x] fill out `Changes`
  - [ ] \(optional) add inline comments in diff
- [x] fill out `Testing`
- [ ] \(optional) add `Screenshots`
- [x] assign yourself to the PR

after opening PR
- [x] link PR to notion ticket
- [x] move ticket to `In PR`
- [x] make sure build passes
- [x] ping `@ps` in `#paramedics-dev`
