### PR TITLE
Add menu bar to CCP dashboard

### DIFF
--- a/src/components/CCPDashboard/CCPDashboardPage.tsx
+++ b/src/components/CCPDashboard/CCPDashboardPage.tsx
@@ -44,7 +44,7 @@ const useStyles = makeStyles({
   },
   tabs: {
     background: Colours.White,
-    padding: '0 205px',
+    padding: '0 165px',
   },
   fullHeightGridItem: {
     display: 'flex',

--- a/src/components/CCPDashboard/CCPDashboardPage.tsx
+++ b/src/components/CCPDashboard/CCPDashboardPage.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { Box, Tabs, Tab, makeStyles } from '@material-ui/core';
+import { Box, Tabs, Tab, makeStyles, Typography } from '@material-ui/core';
 import { RouteComponentProps } from 'react-router';
 import { useQuery } from '@apollo/react-hooks';
 import { useAllPatients } from '../../graphql/queries/hooks/patients';
+import { GET_CCP_BY_ID } from '../../graphql/queries/ccps';
 import { Colours } from '../../styles/Constants';
 import {
   GET_ALL_PATIENTS,
@@ -13,6 +14,7 @@ import { PatientOverview } from './PatientOverview';
 import { HospitalOverview } from './HospitalOverview';
 import LoadingState from '../common/LoadingState';
 import MenuAppBar from '../common/MenuAppBar';
+import LocationOnOutlinedIcon from '@material-ui/icons/LocationOnOutlined';
 
 interface TParams {
   eventId: string;
@@ -71,6 +73,13 @@ const useStyles = makeStyles({
     display: 'flex',
     alignItems: 'center',
   },
+  menuBarTitle: {
+    display: 'inline-block',
+  },
+  locationIcon: {
+    fontSize: '20px',
+    marginLeft: '16px',
+  },
 });
 
 const TabPanel = (props: TabPanelProps) => {
@@ -95,6 +104,9 @@ const CCPDashboardPage = ({ match }: RouteComponentProps<TParams>) => {
   useAllPatients();
   // Should switch to fetching patients from cache
   const { data, loading } = useQuery(GET_ALL_PATIENTS);
+  const { loading: ccpLoading, data: ccpInfo } = useQuery(GET_CCP_BY_ID, {
+    variables: { id: ccpId },
+  });
   const allPatients: Array<Patient> = data ? data.patients : [];
   const patients = React.useMemo(
     () =>
@@ -121,12 +133,31 @@ const CCPDashboardPage = ({ match }: RouteComponentProps<TParams>) => {
     [patients]
   );
 
-  if (loading) {
+  if (loading || ccpLoading) {
     return <LoadingState />;
   }
+
+  const currentCcp = ccpInfo.collectionPoint;
+
+  const menuBarTitle = (
+    <>
+      {currentCcp.name}
+      <div className={classes.menuBarTitle}>
+        <LocationOnOutlinedIcon className={classes.locationIcon} />
+        <Typography variant="caption" className={classes.menuBarTitle}>
+          100 University
+        </Typography>
+      </div>
+    </>
+  );
+
   return (
     <Box className={classes.root}>
-      <MenuAppBar pageTitle="Directory" eventId={eventId} selectedCcp={ccpId} />
+      <MenuAppBar
+        pageTitle={menuBarTitle}
+        eventId={eventId}
+        selectedCcp={ccpId}
+      />
       <Tabs
         className={classes.tabs}
         value={tab}

--- a/src/components/CCPDashboard/CCPDashboardPage.tsx
+++ b/src/components/CCPDashboard/CCPDashboardPage.tsx
@@ -12,6 +12,7 @@ import {
 import { PatientOverview } from './PatientOverview';
 import { HospitalOverview } from './HospitalOverview';
 import LoadingState from '../common/LoadingState';
+import MenuAppBar from '../common/MenuAppBar';
 
 interface TParams {
   eventId: string;
@@ -41,7 +42,7 @@ const useStyles = makeStyles({
   },
   tabs: {
     background: Colours.White,
-    padding: '0 56px',
+    padding: '0 205px',
   },
   fullHeightGridItem: {
     display: 'flex',
@@ -125,6 +126,7 @@ const CCPDashboardPage = ({ match }: RouteComponentProps<TParams>) => {
   }
   return (
     <Box className={classes.root}>
+      <MenuAppBar pageTitle="Directory" eventId={eventId} selectedCcp={ccpId} />
       <Tabs
         className={classes.tabs}
         value={tab}

--- a/src/components/CCPDashboard/CCPDashboardPage.tsx
+++ b/src/components/CCPDashboard/CCPDashboardPage.tsx
@@ -78,6 +78,7 @@ const useStyles = makeStyles({
   },
   locationIcon: {
     fontSize: '20px',
+    verticalAlign: 'middle',
     marginLeft: '16px',
   },
 });

--- a/src/components/common/MenuAppBar.tsx
+++ b/src/components/common/MenuAppBar.tsx
@@ -25,6 +25,7 @@ import { Colours } from '../../styles/Constants';
 interface MenuAppBarProps {
   eventId: string;
   pageTitle: string;
+  selectedCcp?: string;
 }
 
 const useStyles = makeStyles({
@@ -47,6 +48,13 @@ const useStyles = makeStyles({
   active: {
     backgroundColor: 'red',
   },
+  activeCcp: {
+    color: Colours.White,
+    backgroundColor: Colours.Secondary,
+    '&:hover': {
+      backgroundColor: Colours.Secondary,
+    },
+  },
   viewEventsLink: {
     position: 'absolute',
     bottom: 0,
@@ -55,7 +63,7 @@ const useStyles = makeStyles({
 });
 
 export default function MenuAppBar(props: MenuAppBarProps) {
-  const { pageTitle, eventId } = props;
+  const { pageTitle, eventId, selectedCcp } = props;
   const history = useHistory();
   const classes = useStyles();
   const [isMenuOpen, setIsMenuOpen] = React.useState(false);
@@ -134,9 +142,18 @@ export default function MenuAppBar(props: MenuAppBarProps) {
                 button
                 key={ccp.name}
                 onClick={() => handleCCPClick(ccp.id)}
+                className={
+                  selectedCcp && selectedCcp === ccp.id ? classes.activeCcp : ''
+                }
               >
                 <ListItemIcon>
-                  <RoomOutlinedIcon />
+                  <RoomOutlinedIcon
+                    className={
+                      selectedCcp && selectedCcp === ccp.id
+                        ? classes.activeCcp
+                        : ''
+                    }
+                  />
                 </ListItemIcon>
                 <Typography variant="body2">{ccp.name}</Typography>
               </ListItem>

--- a/src/components/common/MenuAppBar.tsx
+++ b/src/components/common/MenuAppBar.tsx
@@ -24,7 +24,7 @@ import { Colours } from '../../styles/Constants';
 
 interface MenuAppBarProps {
   eventId: string;
-  pageTitle: string;
+  pageTitle: string | React.ReactNode;
   selectedCcp?: string;
 }
 


### PR DESCRIPTION
[Notion ticket](https://www.notion.so/uwblueprintexecs/396370c5e09f4c28bc7f455a7e84c908?v=3751aa62a2594c74b7e0ecb363304c24&p=ff794716beac4d77a0274c00436e9017)

## Changes
- Added `MenuAppBar` to `CCPDashboardPage` component
- Added new optional prop, `selectedCcp`, to `MenuAppBar` to highlight the current CCP
- Added new class to highlight current CCP in `MenuAppBar`
- Changed padding of "Hospital Overview" tab bar to be aligned with the hospitals box underneath

## Screenshots
New CCP dashboard screen with menu bar and aligned bar underneath
![image](https://user-images.githubusercontent.com/28452372/96351345-b26cbf00-1088-11eb-8685-698e8adaa8df.png)


Highlighted current CCP in MenuAppBar
![image](https://user-images.githubusercontent.com/28452372/95278593-89ddfd00-081e-11eb-96f7-40b6ae8da14e.png)


## Testing
- Check that the MenuAppBar opens properly on CCP dashboard pages
- Check that the current CCP is highlighted correctly
- Verify that the MenuAppBar isn't broken for the EventDashboardPage, when a CCP isn't selected

## Checklist
>[Code review doc for reference](https://www.notion.so/uwblueprintexecs/Code-Review-a21fc85b00394f488e92d9d605f6b2bc)

before opening PR
- [x] check notion ticket
- [x] run linter
- [x] go through file diff

filling out PR
- [x] descriptive title
- [x] update `notion ticket` link
- [x] fill out `Changes`
  - [x] \(optional) add inline comments in diff
- [x] fill out `Testing`
- [x] \(optional) add `Screenshots`
- [x] assign yourself to the PR

after opening PR
- [x] link PR to notion ticket
- [x] move ticket to `In PR`
- [x] make sure build passes
- [x] ping `@ps` in `#paramedics-dev`
