### PR TITLE
Archive Event Cleanup

### DIFF
--- a/src/components/EventOverview/EventsPage.tsx
+++ b/src/components/EventOverview/EventsPage.tsx
@@ -42,7 +42,7 @@ const EventsPage = () => {
   const classes = useStyles();
   const location = useLocation<LocationState>();
   const { addedEventId } = location.state || { addedEventId: null };
-  const [archivedEventId, setArchivedEventId] = useState('');
+  const [lastUpdatedEventId, setLastUpdatedEventId] = useState(addedEventId);
   const [selectedTab, setTab] = useState(0);
   const [eventToBeDeleted, setEventToBeDeleted] = useState<Event | null>(null);
 
@@ -59,6 +59,7 @@ const EventsPage = () => {
     event: React.ChangeEvent<unknown>,
     newValue: number
   ) => {
+    setLastUpdatedEventId(null);
     setTab(newValue);
   };
 
@@ -99,7 +100,7 @@ const EventsPage = () => {
         isActive: false,
       },
     });
-    setArchivedEventId(event.id);
+    setLastUpdatedEventId(event.id);
     setTab(1);
   };
 
@@ -113,7 +114,7 @@ const EventsPage = () => {
         isActive: true,
       },
     });
-    setArchivedEventId(event.id);
+    setLastUpdatedEventId(event.id);
     setTab(0);
   };
 
@@ -155,9 +156,7 @@ const EventsPage = () => {
                 date={event.eventDate}
                 eventTitle={event.name}
                 isActive={event.isActive}
-                isNew={
-                  event.id === addedEventId || event.id === archivedEventId
-                }
+                isNew={event.id === lastUpdatedEventId}
                 address="N/A"
                 handleClick={() => history.push(`/events/${event.id}`)}
                 handleArchiveEvent={() => handleArchiveEvent(event)}

--- a/src/components/EventOverview/EventsPage.tsx
+++ b/src/components/EventOverview/EventsPage.tsx
@@ -42,6 +42,7 @@ const EventsPage = () => {
   const classes = useStyles();
   const location = useLocation<LocationState>();
   const { addedEventId } = location.state || { addedEventId: null };
+  const [archivedEventId, setArchivedEventId] = useState('');
   const [selectedTab, setTab] = useState(0);
   const [eventToBeDeleted, setEventToBeDeleted] = useState<Event | null>(null);
 
@@ -88,8 +89,8 @@ const EventsPage = () => {
   });
   const events: Array<Event> = data ? data.events : [];
 
-  const handleArchiveEvent = (event: Event) => {
-    editEvent({
+  const handleArchiveEvent = async (event: Event) => {
+    await editEvent({
       variables: {
         id: event.id,
         name: event.name,
@@ -98,9 +99,12 @@ const EventsPage = () => {
         isActive: false,
       },
     });
+    setArchivedEventId(event.id);
+    setTab(1);
   };
-  const handleUnarchiveEvent = (event: Event) => {
-    editEvent({
+
+  const handleUnarchiveEvent = async (event: Event) => {
+    await editEvent({
       variables: {
         id: event.id,
         name: event.name,
@@ -109,6 +113,8 @@ const EventsPage = () => {
         isActive: true,
       },
     });
+    setArchivedEventId(event.id);
+    setTab(0);
   };
 
   const handleDeleteEvent = async (event: Event) => {
@@ -149,7 +155,9 @@ const EventsPage = () => {
                 date={event.eventDate}
                 eventTitle={event.name}
                 isActive={event.isActive}
-                isNew={event.id === addedEventId}
+                isNew={
+                  event.id === addedEventId || event.id === archivedEventId
+                }
                 address="N/A"
                 handleClick={() => history.push(`/events/${event.id}`)}
                 handleArchiveEvent={() => handleArchiveEvent(event)}


### PR DESCRIPTION
[Notion ticket](https://www.notion.so/uwblueprintexecs/archive-event-card-cleanup-1b64ce8fa69a45fd93020db66d2ece6e)

## Changes
- Highlights newly archived/unarchived events
- After archiving/unarchiving event, routes patient to corresponding tab

## Screenshots
<img width="707" alt="image" src="https://user-images.githubusercontent.com/38408276/95920466-7d592780-0d7d-11eb-98b0-6157f2b5247d.png">
<img width="707" alt="image" src="https://user-images.githubusercontent.com/38408276/95920343-4420b780-0d7d-11eb-8dc1-e90cddbd8ef6.png">

## Testing
- Try archiving/unarchiving event, check you are taken to the correct tab and the event is highlighted in blue
- Try navigating away, then back from the page and check event is no longer highlighted

## Checklist
>[Code review doc for reference](https://www.notion.so/uwblueprintexecs/Code-Review-a21fc85b00394f488e92d9d605f6b2bc)

before opening PR
- [x] check notion ticket
- [x] run linter
- [x] go through file diff

filling out PR
- [x] descriptive title
- [x] update `notion ticket` link
- [x] fill out `Changes`
  - [ ] \(optional) add inline comments in diff
- [x] fill out `Testing`
- [x] \(optional) add `Screenshots`
- [x] assign yourself to the PR

after opening PR
- [x] link PR to notion ticket
- [x] move ticket to `In PR`
- [ ] make sure build passes
- [ ] ping `@ps` in `#paramedics-dev`
