### PR TITLE
Fix warning as a result of unnecessary useEffect

### DIFF
--- a/src/components/PatientProfile/PatientProfilePage.tsx
+++ b/src/components/PatientProfile/PatientProfilePage.tsx
@@ -110,7 +110,7 @@ const PatientProfilePage = ({
   });
 
   const [formFields, setFormFields] = useState<FormFields>({
-    barcodeValue: '',
+    barcodeValue: mode === 'new' && !!barcodeValue ? barcodeValue : '',
     triage: TriageLevel.GREEN,
     gender: Gender.M,
     age: null,
@@ -156,12 +156,6 @@ const PatientProfilePage = ({
       setTransportConfirmed(status === Status.TRANSPORTED);
     }
   }, [data, loading, mode]);
-
-  useEffect(() => {
-    if (mode === 'new' && barcodeValue) {
-      setFormFields({ ...formFields, barcodeValue });
-    }
-  }, [mode, barcodeValue]);
 
   const handleDeleteClick = () => {
     setDeleteClicked(true);


### PR DESCRIPTION
[Notion ticket](https://www.notion.so/uwblueprintexecs/refactor-patient-form-fields-1335aa35de664394b84ab0b620a16905)

## Changes
- Removed an unnecessary `useEffect` that was also causing warnings

## Testing
- Verify that add/edit patient flow still works

## Checklist
>[Code review doc for reference](https://www.notion.so/uwblueprintexecs/Code-Review-a21fc85b00394f488e92d9d605f6b2bc)

before opening PR
- [x] check notion ticket
- [x] run linter
- [x] go through file diff

filling out PR
- [x] descriptive title
- [x] update `notion ticket` link
- [ ] update `figma link`
- [x] fill out `Changes`
  - [ ] \(optional) add inline comments in diff
- [x] fill out `Testing`
- [ ] \(optional) add `Screenshots`
- [x] assign yourself to the PR

after opening PR
- [x] link PR to notion ticket
- [x] move ticket to `In PR`
- [x] make sure build passes
- [ ] ping `@ps` in `#paramedics-dev`
