### PR TITLE
Change automatic -1 runNumber to null

### DIFF
--- a/src/components/PatientProfile/PatientProfilePage.tsx
+++ b/src/components/PatientProfile/PatientProfilePage.tsx
@@ -249,7 +249,7 @@ const PatientProfilePage = ({
           age: formFields.age ? parseInt(formFields.age.toString()) : -1,
           runNumber: formFields.runNumber
             ? parseInt(formFields.runNumber.toString())
-            : -1,
+            : null,
           barcodeValue: formFields.barcodeValue
             ? formFields.barcodeValue.toString()
             : '',
@@ -272,7 +272,7 @@ const PatientProfilePage = ({
           age: formFields.age ? parseInt(formFields.age.toString()) : -1,
           runNumber: formFields.runNumber
             ? parseInt(formFields.runNumber.toString())
-            : -1,
+            : null,
           barcodeValue: formFields.barcodeValue
             ? formFields.barcodeValue.toString()
             : '',


### PR DESCRIPTION
[Notion ticket](https://www.notion.so/uwblueprintexecs/run-numbers-1-8475f8a7003b4829a24275262ba3f4b8)

Related backend ticket: https://github.com/uwblueprint/paramedics-web/pull/79

## Changes
- Previously, when `runNumber` was blank while adding/editing a patient, the `runNumber` would be set to `-1`
- This change sets `runNumber` to `null` instead

## Screenshots

## Testing
- Create a patient with `runNumber` left blank --> patient `runNumber` should be null NOT -1
- Edit a patient to have no `runNumber` --> patient `runNumber` should be null NOT -1

## Checklist
>[Code review doc for reference](https://www.notion.so/uwblueprintexecs/Code-Review-a21fc85b00394f488e92d9d605f6b2bc)

before opening PR
- [x] check notion ticket
- [x] run linter
- [x] go through file diff

filling out PR
- [x] descriptive title
- [x] update `notion ticket` link
- [ ] update `figma link`
- [x] fill out `Changes`
  - [ ] \(optional) add inline comments in diff
- [x] fill out `Testing`
- [ ] \(optional) add `Screenshots`
- [x] assign yourself to the PR

after opening PR
- [x] link PR to notion ticket
- [x] move ticket to `In PR`
- [x] make sure build passes
- [x] ping `@ps` in `#paramedics-dev`
