### PR TITLE
Remove Omitted from Status

### DIFF
--- a/src/components/CCPDashboard/PatientInfoTable.tsx
+++ b/src/components/CCPDashboard/PatientInfoTable.tsx
@@ -280,7 +280,7 @@ export const PatientInfoTable = ({
         [Status.ON_SITE]: 'On Scene',
         [Status.TRANSPORTED]: 'Transported',
         [Status.RELEASED]: 'Released',
-        [Status.DELETED]: 'Omitted/Deleted',
+        [Status.DELETED]: 'Deleted',
       };
 
       return (

--- a/src/components/CCPDashboard/PatientInfoTableWithFilters.tsx
+++ b/src/components/CCPDashboard/PatientInfoTableWithFilters.tsx
@@ -120,8 +120,8 @@ const statusFilters: FilterOptionObject = {
     value: Status.RELEASED,
     selected: false,
   },
-  Omit: {
-    label: 'Omit',
+  Deleted: {
+    label: 'Deleted',
     value: Status.DELETED,
     selected: false,
   },

--- a/src/components/CCPDashboard/PatientOverview.tsx
+++ b/src/components/CCPDashboard/PatientOverview.tsx
@@ -94,7 +94,7 @@ export const PatientOverview = (props: PatientOverviewProps) => {
     createCategoryData('On Scene', Status.ON_SITE),
     createCategoryData('Transported', Status.TRANSPORTED),
     createCategoryData('Released', Status.RELEASED),
-    createCategoryData('Omitted/Deleted', Status.DELETED),
+    createCategoryData('Deleted', Status.DELETED),
   ];
 
   const noBorderLastRow = (index) =>


### PR DESCRIPTION
[Notion ticket](https://www.notion.so/uwblueprintexecs/Omitted-Deleted-inconsistent-copy-9b7f8ecfc14a442dbdb2a5a6c1cbb542)

## Changes
- Remove 'Omitted' from the status option in filter tags, patient table status, and category table

## Screenshots
Before
![image](https://user-images.githubusercontent.com/41495076/99888359-40087500-2c1a-11eb-9e29-7c47bc021e04.png)

After
![image](https://user-images.githubusercontent.com/41495076/99888360-43036580-2c1a-11eb-8260-e4ec1aae59af.png)

## Testing
- `Omit/Omitted` should not appear in filter tags, patient table status, and category table

## Checklist
>[Code review doc for reference](https://www.notion.so/uwblueprintexecs/Code-Review-a21fc85b00394f488e92d9d605f6b2bc)

before opening PR
- [x] check notion ticket
- [x] run linter
- [x] go through file diff

filling out PR
- [x] descriptive title
- [x] update `notion ticket` link
- [ ] update `figma link`
- [x] fill out `Changes`
  - [ ] \(optional) add inline comments in diff
- [x] fill out `Testing`
- [x] \(optional) add `Screenshots`
- [x] assign yourself to the PR

after opening PR
- [x] link PR to notion ticket
- [x] move ticket to `In PR`
- [x] make sure build passes
- [x] ping `@ps` in `#paramedics-dev`
