### PR TITLE
Make "Delete" option red when clicking 3 dots on event card

### DIFF
--- a/src/components/EventOverview/CardOptions.tsx
+++ b/src/components/EventOverview/CardOptions.tsx
@@ -30,9 +30,6 @@ const useCardOptionsStyles = makeStyles({
   },
   deleteButton: {
     color: Colours.Danger,
-    '&:hover': {
-      color: Colours.Danger,
-    },
   },
 });
 
@@ -133,8 +130,7 @@ const CardOptions: CardOptions = ({
           <MenuItem onClick={handleOpenArchiveDialog}>Archive</MenuItem>
           <MenuItem onClick={handleEditEvent}>Edit</MenuItem>
           <MenuItem
-            // style={{ backgroundColor: Colours.Danger }}
-            classes={{ root: classes.deleteButton, selected: classes.deleteButton }}
+            classes={{ root: classes.deleteButton }}
             onClick={handleOpenDeleteDialog}
           >
             Delete

--- a/src/components/EventOverview/CardOptions.tsx
+++ b/src/components/EventOverview/CardOptions.tsx
@@ -6,6 +6,7 @@ import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
 import { makeStyles } from '@material-ui/core/styles';
 import ConfirmModal from '../common/ConfirmModal';
+import { Colours } from '../../styles/Constants';
 
 type CardOptions = ({
   eventId,
@@ -26,6 +27,12 @@ type CardOptions = ({
 const useCardOptionsStyles = makeStyles({
   iconButtonRoot: {
     padding: 'unset',
+  },
+  deleteButton: {
+    color: Colours.Danger,
+    '&:hover': {
+      color: Colours.Danger,
+    },
   },
 });
 
@@ -125,7 +132,13 @@ const CardOptions: CardOptions = ({
         >
           <MenuItem onClick={handleOpenArchiveDialog}>Archive</MenuItem>
           <MenuItem onClick={handleEditEvent}>Edit</MenuItem>
-          <MenuItem onClick={handleOpenDeleteDialog}>Delete</MenuItem>
+          <MenuItem
+            // style={{ backgroundColor: Colours.Danger }}
+            classes={{ root: classes.deleteButton, selected: classes.deleteButton }}
+            onClick={handleOpenDeleteDialog}
+          >
+            Delete
+          </MenuItem>
         </Menu>
       </>
     );


### PR DESCRIPTION

[Notion ticket](https://www.notion.so/uwblueprintexecs/event-card-red-delete-b1e1a3ef7ecc4dbb8523da68c4c009fa)


## Changes
- Make "Delete" option red on event card when clicking the three dots

## Screenshots

![Screen Shot 2020-11-24 at 9 19 17 PM](https://user-images.githubusercontent.com/26718994/100174597-b87d6900-2e9a-11eb-9882-f066177fe867.png)

## Testing
- Make sure "Delete" is red 

## Checklist
>[Code review doc for reference](https://www.notion.so/uwblueprintexecs/Code-Review-a21fc85b00394f488e92d9d605f6b2bc)

before opening PR
- [x] check notion ticket
- [x] run linter
- [x] go through file diff

filling out PR
- [x] descriptive title
- [x] update `notion ticket` link
- [ ] update `figma link`
- [x] fill out `Changes`
  - [ ] \(optional) add inline comments in diff
- [x] fill out `Testing`
- [x] \(optional) add `Screenshots`
- [x] assign yourself to the PR

after opening PR
- [x] link PR to notion ticket
- [x] move ticket to `In PR`
- [x] make sure build passes
- [x] ping `@ps` in `#paramedics-dev`
