### PR TITLE
Disable backdrop in dialogs and modals

### DIFF
--- a/src/components/CCPDashboard/PatientInfoTable.tsx
+++ b/src/components/CCPDashboard/PatientInfoTable.tsx
@@ -426,6 +426,7 @@ export const PatientInfoTable = ({
           open={openDetails}
           onClose={handleCloseDetails}
           PaperProps={{ className: classes.detailsDialog }}
+          disableBackdropClick
         >
           <PatientDetailsDialog
             patient={(selectedPatient as unknown) as Patient}

--- a/src/components/EventCreation/CancelModal.tsx
+++ b/src/components/EventCreation/CancelModal.tsx
@@ -41,7 +41,7 @@ const CancelModal: React.FC<{
 }> = ({ open, handleClose }: { open: boolean; handleClose: () => void }) => {
   const classes = useModalStyles();
   return (
-    <Modal open={open} onClose={handleClose}>
+    <Modal open={open} onClose={handleClose} disableBackdropClick>
       <Container classes={{ root: classes.root }}>
         <Typography classes={{ root: classes.text }}>
           Are you sure you want to cancel this event?

--- a/src/components/EventCreation/SelectDateModal.tsx
+++ b/src/components/EventCreation/SelectDateModal.tsx
@@ -102,7 +102,7 @@ const SelectDateModal: React.FC<{
     eventDate ? new Date(eventDate) : null
   );
   return (
-    <Modal open={open} onClose={handleClose}>
+    <Modal open={open} onClose={handleClose} disableBackdropClick>
       <Container classes={{ root: classes.root }}>
         <Typography variant="h6" classes={{ root: classes.text }}>
           Select Event Date:

--- a/src/components/EventDashboard/ActionConfirmationDialog.tsx
+++ b/src/components/EventDashboard/ActionConfirmationDialog.tsx
@@ -58,6 +58,7 @@ export const ActionConfirmationDialog = (
       onClose={handleClose}
       aria-labelledby="alert-dialog-title"
       aria-describedby="alert-dialog-description"
+      disableBackdropClick
     >
       <DialogTitle id="alert-dialog-title">
         {`${includeOrExclude === 'include' ? 'Include' : 'Exclude'} ${

--- a/src/components/Maps/Sidebar.tsx
+++ b/src/components/Maps/Sidebar.tsx
@@ -62,6 +62,7 @@ const Sidebar = ({
       onClose={onClose}
       PaperProps={{ style: { width: '400px' } }}
       disableScrollLock
+      disableBackdropClick
     >
       <Typography variant="h4" classes={{ root: styles.title }}>
         {title}

--- a/src/components/PatientProfile/PatientTransportPage.tsx
+++ b/src/components/PatientProfile/PatientTransportPage.tsx
@@ -88,7 +88,7 @@ const PatientTransportPage = ({
   const classes = useStyles();
 
   return (
-    <Dialog fullScreen open={open} onClose={handleClose}>
+    <Dialog fullScreen open={open} onClose={handleClose} disableBackdropClick>
       <AppBar position="relative" className={classes.appBar}>
         <Toolbar variant="dense">
           <Typography variant="h6" className={classes.appBarText}>

--- a/src/components/common/ConfirmModal.tsx
+++ b/src/components/common/ConfirmModal.tsx
@@ -70,7 +70,11 @@ const ConfirmModal = ({
   const dialogStyle = dialogStyles();
 
   return (
-    <Dialog classes={{ paper: dialogStyle.paper }} open={open}>
+    <Dialog
+      classes={{ paper: dialogStyle.paper }}
+      open={open}
+      disableBackdropClick
+    >
       <DialogTitle classes={{ root: dialogStyle.dialogTitle }}>
         {title}
       </DialogTitle>

--- a/src/components/common/ConfirmModal.tsx
+++ b/src/components/common/ConfirmModal.tsx
@@ -100,7 +100,6 @@ const ConfirmModal = ({
           onClick={(event) => {
             event.stopPropagation();
             handleClickAction();
-            handleClickCancel();
           }}
         >
           <Typography variant="body1">{actionLabel}</Typography>


### PR DESCRIPTION
[Notion ticket](https://www.notion.so/uwblueprintexecs/9224caeb21ce4350b8a1dc378d393323?v=43f44ac04d734394b7f7edc636c523b4)

[Figma link](https://www.figma.com/file/IpOPyv79gBwEohvOJvPV6f/%F0%9F%9A%91-Designs-for-Development-(S20%2C-F20)?node-id=1972%3A36028)

## Changes
- Added the property `disableBackdropClick` to prevent users from closing the modal/dialog by clicking outside of it
    - Fixes problem 1 described in the Notion ticket
    - Also fixes the `ccp dashboard interacts weirdly with the menu popper` problem
- 

## Screenshots

## Testing
- 

## Checklist
>[Code review doc for reference](https://www.notion.so/uwblueprintexecs/Code-Review-a21fc85b00394f488e92d9d605f6b2bc)

before opening PR
- [ ] check notion ticket
- [ ] run linter
- [ ] go through file diff

filling out PR
- [ ] descriptive title
- [ ] update `notion ticket` link
- [ ] update `figma link`
- [ ] fill out `Changes`
  - [ ] \(optional) add inline comments in diff
- [ ] fill out `Testing`
- [ ] \(optional) add `Screenshots`
- [ ] assign yourself to the PR

after opening PR
- [ ] link PR to notion ticket
- [ ] move ticket to `In PR`
- [ ] make sure build passes
- [ ] ping `@ps` in `#paramedics-dev`
