### PR TITLE
Autocomplete positioning and clearing

### DIFF
--- a/src/components/Maps/SearchBar.tsx
+++ b/src/components/Maps/SearchBar.tsx
@@ -89,23 +89,18 @@ const SearchBar = ({
               InputProps={{
                 endAdornment: (
                   <InputAdornment position="end">
-                    {address && (
-                      <>
-                        <IconButton
-                          onClick={() => {
-                            setAddress('');
-                          }}
-                        >
-                          <ClearIcon />
-                        </IconButton>
-                      </>
-                    )}
-                    {!address && (
-                      <>
-                        <IconButton>
-                          <SearchIcon />
-                        </IconButton>
-                      </>
+                    {address ? (
+                      <IconButton
+                        onClick={() => {
+                          setAddress('');
+                        }}
+                      >
+                        <ClearIcon />
+                      </IconButton>
+                    ) : (
+                      <IconButton>
+                        <SearchIcon />
+                      </IconButton>
                     )}
                   </InputAdornment>
                 ),

--- a/src/components/Maps/SearchBar.tsx
+++ b/src/components/Maps/SearchBar.tsx
@@ -5,6 +5,7 @@ import ListItem from '@material-ui/core/ListItem';
 import Typography from '@material-ui/core/Typography';
 import IconButton from '@material-ui/core/IconButton';
 import InputAdornment from '@material-ui/core/InputAdornment';
+import ClearIcon from '@material-ui/icons/Clear';
 import SearchIcon from '@material-ui/icons/Search';
 import PlacesAutocomplete, {
   geocodeByAddress,
@@ -32,8 +33,10 @@ const useStyles = makeStyles({
 
 const SearchBar = ({
   onComplete,
+  onAutocompleteClick,
 }: {
   onComplete: ({ latitude, longitude, address }) => void;
+  onAutocompleteClick: () => void;
 }) => {
   const [address, setAddress] = useState('');
   const [menuOpen, setMenuOpen] = useState(false);
@@ -86,9 +89,24 @@ const SearchBar = ({
               InputProps={{
                 endAdornment: (
                   <InputAdornment position="end">
-                    <IconButton>
-                      <SearchIcon />
-                    </IconButton>
+                    {address && (
+                      <>
+                        <IconButton
+                          onClick={() => {
+                            setAddress('');
+                          }}
+                        >
+                          <ClearIcon />
+                        </IconButton>
+                      </>
+                    )}
+                    {!address && (
+                      <>
+                        <IconButton>
+                          <SearchIcon />
+                        </IconButton>
+                      </>
+                    )}
                   </InputAdornment>
                 ),
                 inputProps: getInputProps({
@@ -98,6 +116,7 @@ const SearchBar = ({
               onFocus={() => {
                 setMenuOpen(true);
               }}
+              onClick={onAutocompleteClick}
               value={address}
               className={styles.sidebarTextField}
               validators={['required']}

--- a/src/components/Maps/Sidebar.tsx
+++ b/src/components/Maps/Sidebar.tsx
@@ -4,6 +4,8 @@ import Typography from '@material-ui/core/Typography';
 import Drawer from '@material-ui/core/Drawer';
 import Container from '@material-ui/core/Container';
 import Button from '@material-ui/core/Button';
+import Collapse from '@material-ui/core/Collapse';
+import KeyboardBackspaceIcon from '@material-ui/icons/KeyboardBackspace';
 import { ValidatorForm, TextValidator } from 'react-material-ui-form-validator';
 import SearchBar from './SearchBar';
 import { Colours } from '../../styles/Constants';
@@ -27,6 +29,12 @@ const useStyles = makeStyles({
     marginTop: '30px',
     padding: '0px 30px 0px 16px',
   },
+  autocompleteBackContainer: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    marginTop: '20px',
+    padding: '0px 30px 10px 16px',
+  },
 });
 
 const Sidebar = ({
@@ -44,6 +52,9 @@ const Sidebar = ({
   const [latitude, setLatitude] = React.useState(0);
   const [longitude, setLongitude] = React.useState(0);
   const [label, setLabel] = React.useState('');
+  const [isAutocompleteClicked, setIsAutocompleteClicked] = React.useState(
+    false
+  );
   const styles = useStyles();
 
   const handleLabelChange = (e: React.ChangeEvent<HTMLElement>) => {
@@ -56,6 +67,14 @@ const Sidebar = ({
     setAddress(address);
   };
 
+  const handleAutocompleteClicked = () => {
+    setIsAutocompleteClicked(true);
+  };
+
+  const handleBackClicked = () => {
+    setIsAutocompleteClicked(false);
+  };
+
   return (
     <Drawer
       open={open}
@@ -63,9 +82,11 @@ const Sidebar = ({
       PaperProps={{ style: { width: '400px' } }}
       disableScrollLock
     >
-      <Typography variant="h4" classes={{ root: styles.title }}>
-        {title}
-      </Typography>
+      <Collapse in={!isAutocompleteClicked}>
+        <Typography variant="h4" classes={{ root: styles.title }}>
+          {title}
+        </Typography>
+      </Collapse>
       <ValidatorForm
         onSubmit={(e) => {
           onComplete({
@@ -79,17 +100,30 @@ const Sidebar = ({
           e.preventDefault();
         }}
       >
-        <Typography variant="body1" classes={{ root: styles.label }}>
-          Name:
-        </Typography>
-        <TextValidator
-          placeholder="Pin name"
-          onChange={handleLabelChange}
-          value={label}
-          validators={['required']}
-          errorMessages={['A pin name is required']}
-          className={styles.pinLabelField}
-        />
+        <Collapse in={!isAutocompleteClicked}>
+          <Typography variant="body1" classes={{ root: styles.label }}>
+            Name:
+          </Typography>
+          <TextValidator
+            placeholder="Pin name"
+            onChange={handleLabelChange}
+            value={label}
+            validators={['required']}
+            errorMessages={['A pin name is required']}
+            className={styles.pinLabelField}
+          />
+        </Collapse>
+        <Collapse in={isAutocompleteClicked}>
+          <Container classes={{ root: styles.autocompleteBackContainer }}>
+            <Button
+              onClick={handleBackClicked}
+              style={{ color: Colours.Secondary }}
+              startIcon={<KeyboardBackspaceIcon />}
+            >
+              Back
+            </Button>
+          </Container>
+        </Collapse>
         <Typography variant="body1" classes={{ root: styles.label }}>
           Pin Location:
         </Typography>
@@ -101,22 +135,26 @@ const Sidebar = ({
               address,
             })
           }
+          onAutocompleteClick={handleAutocompleteClicked}
         />
-        <Container classes={{ root: styles.buttonContainer }}>
-          <Button
-            style={{ color: Colours.Secondary }}
-            onClick={() => {
-              setLabel('');
-              setAddress('');
-              onClose();
-            }}
-          >
-            Cancel
-          </Button>
-          <Button variant="contained" color="secondary" type="submit">
-            Complete
-          </Button>
-        </Container>
+        <Collapse in={!isAutocompleteClicked}>
+          <Container classes={{ root: styles.buttonContainer }}>
+            <Button
+              variant="outlined"
+              style={{ color: Colours.Secondary }}
+              onClick={() => {
+                setLabel('');
+                setAddress('');
+                onClose();
+              }}
+            >
+              Cancel
+            </Button>
+            <Button variant="contained" color="secondary" type="submit">
+              Complete
+            </Button>
+          </Container>
+        </Collapse>
       </ValidatorForm>
     </Drawer>
   );


### PR DESCRIPTION
[Notion ticket](https://www.notion.so/396370c5e09f4c28bc7f455a7e84c908?v=3d4d369c668e4d2581a2517666768b44&p=4c33778cafdf4c2ab49185ee6679e016)

[Figma link](https://www.figma.com/file/IpOPyv79gBwEohvOJvPV6f/%F0%9F%9A%91-Designs-for-Development-S20-F20?node-id=3762%3A10757)

## Changes
- In order to make sure that autocomplete suggestions are not covered by the iPad keyboard, we are making a new view for the autocompletion location
- Added a clear button to the autocompletion field that activates if the location filled is filled
- Added a back button in the new view so that the user can go back to the previous view and submit the field
- Outlined the cancel button to make it more consistent with Figma 

## Screenshots
<img width="1437" alt="Screen Shot 2020-12-01 at 6 57 06 PM" src="https://user-images.githubusercontent.com/21224282/100821298-51693280-340d-11eb-8ab1-60a70acd9381.png">

## Testing
- Add an address and make sure that the new view is opened
- Clear an address
- Make sure that the back button returns you to the previous form view

## Checklist
>[Code review doc for reference](https://www.notion.so/uwblueprintexecs/Code-Review-a21fc85b00394f488e92d9d605f6b2bc)

before opening PR
- [x] check notion ticket
- [x] run linter
- [x] go through file diff

filling out PR
- [x] descriptive title
- [x] update `notion ticket` link
- [x] update `figma link`
- [x] fill out `Changes`
  - [ ] \(optional) add inline comments in diff
- [x] fill out `Testing`
- [x] \(optional) add `Screenshots`
- [x] assign yourself to the PR

after opening PR
- [x] link PR to notion ticket
- [x] move ticket to `In PR`
- [x] make sure build passes
- [x] ping `@ps` in `#paramedics-dev`
