### PR TITLE
Added wrapped text to patient's profile page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,11 +46,7 @@ function App() {
         path="/events/:eventId/edit"
         component={(props) => <EventCreationPage mode="edit" {...props} />}
       />
-      <Route
-        exact
-        path="/manage/:resource"
-        component={ResourceOverviewPage}
-      />
+      <Route exact path="/manage/:resource" component={ResourceOverviewPage} />
       <Route exact path="/manage/">
         <Redirect to="/manage/members" />
       </Route>

--- a/src/components/PatientProfile/PatientProfilePage.tsx
+++ b/src/components/PatientProfile/PatientProfilePage.tsx
@@ -458,6 +458,7 @@ const PatientProfilePage = ({
             }}
             value={formFields.notes || ''}
             isValidated={false}
+            isMultiline={true}
           />
           {transportConfirmed === true && (
             <>

--- a/src/components/PatientProfile/PatientProfilePage.tsx
+++ b/src/components/PatientProfile/PatientProfilePage.tsx
@@ -458,7 +458,7 @@ const PatientProfilePage = ({
             }}
             value={formFields.notes || ''}
             isValidated={false}
-            isMultiline={true}
+            isMultiline
           />
           {transportConfirmed === true && (
             <>

--- a/src/components/common/FormField.tsx
+++ b/src/components/common/FormField.tsx
@@ -12,10 +12,13 @@ const useTextFieldStyles = makeStyles({
     padding: '20px',
     marginTop: '0px',
     marginBottom: '20px',
-    height: '120px',
+    minHeight: '120px',
     width: '100%',
     '& .MuiInput-formControl': {
       marginTop: 'auto',
+    },
+    '& .MuiInputBase-multiline': {
+      marginTop: '43.625px',
     },
     '& label': {
       fontWeight: 'bold',
@@ -47,6 +50,7 @@ const FormField: React.FC<{
   readOnly?: boolean;
   disabled?: boolean;
   numeric?: boolean;
+  isMultiline?: boolean;
 }> = ({
   label,
   placeholder,
@@ -59,6 +63,7 @@ const FormField: React.FC<{
   readOnly,
   disabled,
   numeric,
+  isMultiline,
 }: {
   label: string;
   placeholder?: string;
@@ -71,6 +76,7 @@ const FormField: React.FC<{
   readOnly?: boolean;
   disabled?: boolean;
   numeric?: boolean;
+  isMultiline?: boolean;
 }) => {
   const classes = useTextFieldStyles();
   if (isValidated) {
@@ -92,6 +98,7 @@ const FormField: React.FC<{
         onFocus={handleFocus}
         validators={validators}
         errorMessages={errorMessages}
+        multiline={isMultiline}
       />
     );
   }
@@ -112,6 +119,7 @@ const FormField: React.FC<{
       onChange={onChange}
       value={value}
       onFocus={handleFocus}
+      multiline={isMultiline}
     />
   );
 };


### PR DESCRIPTION
[Notion ticket](https://www.notion.so/uwblueprintexecs/wrap-the-text-for-the-notes-field-065184f2040043df86b4a3022abf48c0)

[Figma link](https://www.notion.so/uwblueprintexecs/wrap-the-text-for-the-notes-field-065184f2040043df86b4a3022abf48c0#f6cb2982df004e1582409d31fdba6dce)

## Changes
- Added text wrapping to patient's page

## Screenshots
<img width="1407" alt="Screen Shot 2020-12-12 at 4 53 10 PM" src="https://user-images.githubusercontent.com/59406513/102000261-86da0f80-3c9a-11eb-92db-627269a49f04.png">

## Testing
- Opened up a patient's page in edit patient and typed a really long paragraph.
- Checked if other fields are affected by the new change

## Checklist
>[Code review doc for reference](https://www.notion.so/uwblueprintexecs/Code-Review-a21fc85b00394f488e92d9d605f6b2bc)

before opening PR
- [x] check notion ticket
- [x] run linter
- [x] go through file diff

filling out PR
- [x] descriptive title
- [x] update `notion ticket` link
- [x] update `figma link`
- [x] fill out `Changes`
  - [ ] \(optional) add inline comments in diff
- [x] fill out `Testing`
- [x] \(optional) add `Screenshots`
- [x] assign yourself to the PR

after opening PR
- [x] link PR to notion ticket
- [x] move ticket to `In PR`
- [x] make sure build passes
- [x] ping `@ps` in `#paramedics-dev`
