### PR TITLE
Highlight added/edited resources

### DIFF
--- a/src/components/EventDashboard/EventDashboardPage.tsx
+++ b/src/components/EventDashboard/EventDashboardPage.tsx
@@ -86,7 +86,7 @@ const EventDashboardPage = ({ match }: RouteComponentProps<TParams>) => {
 
   return (
     <Box className={classes.root}>
-      <MenuAppBar pageTitle="Directory" eventId={eventId} selectedDirectory/>
+      <MenuAppBar pageTitle="Directory" eventId={eventId} selectedDirectory />
       <Container className={classes.container}>
         <Typography variant="h3">{event.name}</Typography>
         <Box

--- a/src/components/ResourceForm/AmbulanceFormPage.tsx
+++ b/src/components/ResourceForm/AmbulanceFormPage.tsx
@@ -55,15 +55,17 @@ const AmbulanceFormPage = ({
         data: { ambulances: ambulances.concat([addAmbulance]) },
       });
     },
-    onCompleted() {
+    onCompleted({ addAmbulance }) {
       enqueueSnackbar('Ambulance added.');
-      history.replace('/manage/ambulances');
+      history.replace('/manage/ambulances', {
+        updatedResourceId: addAmbulance.id,
+      });
     },
   });
   const [editAmbulance] = useMutation(EDIT_AMBULANCE, {
     onCompleted() {
       enqueueSnackbar('Ambulance edited.');
-      history.replace('/manage/ambulances');
+      history.replace('/manage/ambulances', { updatedResourceId: ambulanceId });
     },
   });
 

--- a/src/components/ResourceForm/HospitalFormPage.tsx
+++ b/src/components/ResourceForm/HospitalFormPage.tsx
@@ -51,15 +51,17 @@ const HospitalFormPage = ({
         data: { hospitals: hospitals.concat([addHospital]) },
       });
     },
-    onCompleted() {
+    onCompleted({ addHospital }) {
       enqueueSnackbar('Hospital added.');
-      history.replace('/manage/hospitals');
+      history.replace('/manage/hospitals', {
+        updatedResourceId: addHospital.id,
+      });
     },
   });
   const [editHospital] = useMutation(EDIT_HOSPITAL, {
     onCompleted() {
       enqueueSnackbar('Hospital edited.');
-      history.replace('/manage/hospitals');
+      history.replace('/manage/hospitals', { updatedResourceId: hospitalId });
     },
   });
 

--- a/src/components/ResourceForm/UserFormPage.tsx
+++ b/src/components/ResourceForm/UserFormPage.tsx
@@ -63,15 +63,15 @@ const UserFormPage = ({
         data: { users: users.concat([addUser]) },
       });
     },
-    onCompleted() {
+    onCompleted({ addUser }) {
       enqueueSnackbar('Team member added.');
-      history.replace('/manage/members');
+      history.replace('/manage/members', { updatedResourceId: addUser.id });
     },
   });
   const [editUser] = useMutation(EDIT_USER, {
     onCompleted() {
       enqueueSnackbar('Team member edited.');
-      history.replace('/manage/members');
+      history.replace('/manage/members', { updatedResourceId: userId });
     },
   });
 

--- a/src/components/ResourceOverview/AmbulanceOverviewPage.tsx
+++ b/src/components/ResourceOverview/AmbulanceOverviewPage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Typography, IconButton } from '@material-ui/core';
-import { useHistory } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 import { useSnackbar } from 'notistack';
 import { useQuery } from 'react-apollo';
 import { useMutation } from '@apollo/react-hooks';
@@ -12,10 +12,10 @@ import TableContainer from '@material-ui/core/TableContainer';
 import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
 import MoreHorizIcon from '@material-ui/icons/MoreHoriz';
+import clsx from 'clsx';
 import AddResourceButton from './AddResourceButton';
 import ConfirmModal from '../common/ConfirmModal';
 import OptionPopper, { Option } from '../common/OptionPopper';
-
 import { useAllAmbulances } from '../../graphql/queries/hooks/ambulances';
 import {
   GET_ALL_AMBULANCES,
@@ -96,7 +96,12 @@ const useLayout = makeStyles({
     right: '48px',
     bottom: '48px',
   },
+  highlighted: {
+    backgroundColor: Colours.Blue,
+  },
 });
+
+type LocationState = { updatedResourceId: string | null };
 
 const AmbulanceOverviewPage: React.FC = () => {
   const { enqueueSnackbar } = useSnackbar();
@@ -105,6 +110,16 @@ const AmbulanceOverviewPage: React.FC = () => {
   const [selectedAmbulance, setSelectedAmbulance] = React.useState<
     number | null
   >(null);
+  const location = useLocation<LocationState>();
+  const { updatedResourceId: highlightedAmbulanceId } = location.state || { updatedResourceId: null };
+
+  window.history.pushState(
+    {
+      ...location.state,
+      updatedResourceId: null,
+    },
+    ''
+  );
 
   // Update cache
   useAllAmbulances();
@@ -193,7 +208,12 @@ const AmbulanceOverviewPage: React.FC = () => {
 
   const cells = ambulances.map((ambulance: Ambulance) => {
     return (
-      <TableRow key={ambulance.id}>
+      <TableRow
+        key={ambulance.id}
+        className={clsx({
+          [classes.highlighted]: ambulance.id === highlightedAmbulanceId,
+        })}
+      >
         <TableCell classes={{ root: dRow.root }}>
           {`#${ambulance.vehicleNumber}`}
         </TableCell>

--- a/src/components/ResourceOverview/HospitalOverviewPage.tsx
+++ b/src/components/ResourceOverview/HospitalOverviewPage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Typography, IconButton } from '@material-ui/core';
-import { useHistory } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 import { useSnackbar } from 'notistack';
 import { useMutation } from '@apollo/react-hooks';
 import { useQuery } from 'react-apollo';
@@ -12,10 +12,10 @@ import TableContainer from '@material-ui/core/TableContainer';
 import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
 import MoreHorizIcon from '@material-ui/icons/MoreHoriz';
+import clsx from 'clsx';
 import AddResourceButton from './AddResourceButton';
 import ConfirmModal from '../common/ConfirmModal';
 import OptionPopper, { Option } from '../common/OptionPopper';
-
 import { useAllHospitals } from '../../graphql/queries/hooks/hospitals';
 import { GET_ALL_HOSPITALS, Hospital } from '../../graphql/queries/hospitals';
 import { DELETE_HOSPITAL } from '../../graphql/mutations/hospitals';
@@ -93,7 +93,12 @@ const useLayout = makeStyles({
     right: '48px',
     bottom: '48px',
   },
+  highlighted: {
+    backgroundColor: Colours.Blue,
+  },
 });
+
+type LocationState = { updatedResourceId: string | null };
 
 const HospitalOverviewPage: React.FC = () => {
   const history = useHistory();
@@ -101,6 +106,16 @@ const HospitalOverviewPage: React.FC = () => {
   const [openModal, setOpenModal] = React.useState<boolean>(false);
   const [anchorEl, setAnchorEl] = React.useState(null);
   const [selectedHospital, selectHospital] = React.useState<number>(-1);
+  const location = useLocation<LocationState>();
+  const { updatedResourceId: highlightedHospitalId } = location.state || { updatedResourceId: null };
+
+  window.history.pushState(
+    {
+      ...location.state,
+      updatedResourceId: null,
+    },
+    ''
+  );
 
   // Update cache
   useAllHospitals();
@@ -186,7 +201,12 @@ const HospitalOverviewPage: React.FC = () => {
 
   const cells = hospitals.map((hospital: Hospital) => {
     return (
-      <TableRow key={hospital.id}>
+      <TableRow
+        key={hospital.id}
+        className={clsx({
+          [classes.highlighted]: hospital.id === highlightedHospitalId,
+        })}
+      >
         <TableCell classes={{ root: dRow.root }}>{hospital.name}</TableCell>
         <TableCell classes={{ root: optionStyle.root }}>
           <IconButton data-id={hospital.id} onClick={handleClickOptions}>

--- a/src/components/ResourceOverview/ResourceOverviewPage.tsx
+++ b/src/components/ResourceOverview/ResourceOverviewPage.tsx
@@ -103,7 +103,7 @@ const ResourceOverviewPage = ({
       default:
         break;
     }
-    history.push(path, { updatedResourceId: null });
+    history.push(path);
   };
 
   const classes = useLayout();

--- a/src/components/ResourceOverview/ResourceOverviewPage.tsx
+++ b/src/components/ResourceOverview/ResourceOverviewPage.tsx
@@ -103,7 +103,7 @@ const ResourceOverviewPage = ({
       default:
         break;
     }
-    history.push(path);
+    history.push(path, { updatedResourceId: null });
   };
 
   const classes = useLayout();

--- a/src/components/ResourceOverview/UserOverviewPage.tsx
+++ b/src/components/ResourceOverview/UserOverviewPage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Typography, IconButton } from '@material-ui/core';
 import MoreHorizIcon from '@material-ui/icons/MoreHoriz';
-import { useHistory } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 import { useSnackbar } from 'notistack';
 import { useQuery } from 'react-apollo';
 import { useMutation } from '@apollo/react-hooks';
@@ -12,10 +12,10 @@ import TableCell from '@material-ui/core/TableCell';
 import TableContainer from '@material-ui/core/TableContainer';
 import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
+import clsx from 'clsx';
 import AddResourceButton from './AddResourceButton';
 import ConfirmModal from '../common/ConfirmModal';
 import OptionPopper, { Option } from '../common/OptionPopper';
-
 import { GET_ALL_USERS, User } from '../../graphql/queries/users';
 import { useAllUsers } from '../../graphql/queries/hooks/users';
 import { DELETE_USER } from '../../graphql/mutations/users';
@@ -93,7 +93,12 @@ const useLayout = makeStyles({
     right: '48px',
     bottom: '48px',
   },
+  highlighted: {
+    backgroundColor: Colours.Blue,
+  },
 });
+
+type LocationState = { updatedResourceId: string | null };
 
 const UserOverviewPage: React.FC = () => {
   const { enqueueSnackbar } = useSnackbar();
@@ -110,6 +115,16 @@ const UserOverviewPage: React.FC = () => {
   const [openModal, setOpenModal] = React.useState<boolean>(false);
   const [anchorEl, setAnchorEl] = React.useState(null);
   const [selectedMember, selectMember] = React.useState<number>(-1);
+  const location = useLocation<LocationState>();
+  const { updatedResourceId: highlightedUserId } = location.state || { updatedResourceId: null };
+
+  window.history.pushState(
+    {
+      ...location.state,
+      updatedResourceId: null,
+    },
+    ''
+  );
 
   const handleCloseConfirmDelete = () => {
     setAnchorEl(null);
@@ -192,7 +207,12 @@ const UserOverviewPage: React.FC = () => {
 
   const cells = members.map((member: User) => {
     return (
-      <TableRow key={member.id}>
+      <TableRow
+        key={member.id}
+        className={clsx({
+          [classes.highlighted]: member.id === highlightedUserId,
+        })}
+      >
         <TableCell classes={{ root: dRow.root }}>{member.name}</TableCell>
         <TableCell classes={{ root: dRow.root }}>{member.email}</TableCell>
         <TableCell classes={{ root: dRow.root }}>

--- a/src/components/common/MenuAppBar.tsx
+++ b/src/components/common/MenuAppBar.tsx
@@ -82,7 +82,13 @@ const useStyles = makeStyles({
 });
 
 export default function MenuAppBar(props: MenuAppBarProps) {
-  const { pageTitle, eventId, selectedDirectory, selectedMaps, selectedCcp } = props;
+  const {
+    pageTitle,
+    eventId,
+    selectedDirectory,
+    selectedMaps,
+    selectedCcp,
+  } = props;
   const history = useHistory();
   const classes = useStyles();
   const [isMenuOpen, setIsMenuOpen] = React.useState(false);
@@ -163,10 +169,14 @@ export default function MenuAppBar(props: MenuAppBarProps) {
               button
               key="directory"
               onClick={handleDirectoryClick}
-              className={selectedDirectory ? classes.activeRow : classes.sidebarRow}
+              className={
+                selectedDirectory ? classes.activeRow : classes.sidebarRow
+              }
             >
               <ListItemIcon className={classes.sidebarIcon}>
-                <ScanIcon colour={selectedDirectory ? Colours.White : Colours.Black} />
+                <ScanIcon
+                  colour={selectedDirectory ? Colours.White : Colours.Black}
+                />
               </ListItemIcon>
               <Typography variant="body2">Directory</Typography>
             </ListItem>


### PR DESCRIPTION
[Notion ticket](https://www.notion.so/uwblueprintexecs/highlight-added-edited-resources-748751b845a5484e96d1f2a6872a009f)

[Figma link](https://www.figma.com/file/IpOPyv79gBwEohvOJvPV6f/%F0%9F%9A%91-Designs-for-Development-(S20%2C-F20)?node-id=1972%3A36028)

## Changes
- Highlights row of added/edited resources in resource management
- Highlight disappears once you navigate away from the page (eg. switch tabs, refresh)

## Screenshots
<img width="1437" alt="image" src="https://user-images.githubusercontent.com/38408276/103159212-8e1e1480-4794-11eb-81a9-6f37cbefaa83.png">

## Testing
- Try adding/editing an ambulance, user, and hospital and ensure the corresponding resource is highlighted
- Check that the highlight disappears once you navigate away and back to the page

## Checklist
>[Code review doc for reference](https://www.notion.so/uwblueprintexecs/Code-Review-a21fc85b00394f488e92d9d605f6b2bc)

before opening PR
- [x] check notion ticket
- [x] run linter
- [x] go through file diff

filling out PR
- [x] descriptive title
- [x] update `notion ticket` link
- [ ] update `figma link`
- [x] fill out `Changes`
  - [ ] \(optional) add inline comments in diff
- [x] fill out `Testing`
- [x] \(optional) add `Screenshots`
- [x] assign yourself to the PR

after opening PR
- [x] link PR to notion ticket
- [x] move ticket to `In PR`
- [x] make sure build passes
- [x] ping `@ps` in `#paramedics-dev`
