### PR TITLE
Fixed Dialog/Modal Behaviour

### DIFF
--- a/src/components/EventCreation/CancelModal.tsx
+++ b/src/components/EventCreation/CancelModal.tsx
@@ -41,7 +41,7 @@ const CancelModal: React.FC<{
 }> = ({ open, handleClose }: { open: boolean; handleClose: () => void }) => {
   const classes = useModalStyles();
   return (
-    <Modal open={open} onClose={handleClose}>
+    <Modal open={open} onClose={handleClose} disableBackdropClick>
       <Container classes={{ root: classes.root }}>
         <Typography classes={{ root: classes.text }}>
           Are you sure you want to cancel this event?

--- a/src/components/EventCreation/SelectDateModal.tsx
+++ b/src/components/EventCreation/SelectDateModal.tsx
@@ -102,7 +102,7 @@ const SelectDateModal: React.FC<{
     eventDate ? new Date(eventDate) : null
   );
   return (
-    <Modal open={open} onClose={handleClose}>
+    <Modal open={open} onClose={handleClose} disableBackdropClick>
       <Container classes={{ root: classes.root }}>
         <Typography variant="h6" classes={{ root: classes.text }}>
           Select Event Date:

--- a/src/components/common/ConfirmModal.tsx
+++ b/src/components/common/ConfirmModal.tsx
@@ -70,7 +70,11 @@ const ConfirmModal = ({
   const dialogStyle = dialogStyles();
 
   return (
-    <Dialog classes={{ paper: dialogStyle.paper }} open={open}>
+    <Dialog
+      classes={{ paper: dialogStyle.paper }}
+      open={open}
+      onClick={(event) => event.stopPropagation()}
+    >
       <DialogTitle classes={{ root: dialogStyle.dialogTitle }}>
         {title}
       </DialogTitle>
@@ -96,7 +100,6 @@ const ConfirmModal = ({
           onClick={(event) => {
             event.stopPropagation();
             handleClickAction();
-            handleClickCancel();
           }}
         >
           <Typography variant="body1">{actionLabel}</Typography>


### PR DESCRIPTION
[Notion ticket](https://www.notion.so/uwblueprintexecs/Dialog-Modal-Clean-up-d7885c94b20c426cb1258dedac09dd12)

## Changes
- Force users to exit modal via CTAs by disabling backdrop click
- Fixed odd behavior that redirected the user to the Event Card page upon clicking anything besides the CTAs for the Event Card archive and delete modals
    - Added `event.stopPropagation` in `src/components/common/ConfirmModal.tsx`
- Removed `handleClickCancel` in `onClick` handler of `ConfirmModal.tsx`

## Testing
- Confirm that backdrop click is disabled for pages that implement:
   - `ConfirmModal.tsx`
   - `CancelModal.tsx`
   - `SelectDateModal.tsx`
- Confirm that odd redirecting behaviour (2nd point in notion ticket) is fixed

## Checklist
>[Code review doc for reference](https://www.notion.so/uwblueprintexecs/Code-Review-a21fc85b00394f488e92d9d605f6b2bc)

before opening PR
- [x] check notion ticket
- [x] run linter
- [x] go through file diff

filling out PR
- [x] descriptive title
- [x] update `notion ticket` link
- [] update `figma link`
- [x] fill out `Changes`
  - [ ] \(optional) add inline comments in diff
- [x] fill out `Testing`
- [ ] \(optional) add `Screenshots`
- [x] assign yourself to the PR

after opening PR
- [x] link PR to notion ticket
- [x] move ticket to `In PR`
- [x] make sure build passes
- [x] ping `@ps` in `#paramedics-dev`
