### PR TITLE
Clean up events page

### DIFF
--- a/src/components/EventOverview/EventCard.tsx
+++ b/src/components/EventOverview/EventCard.tsx
@@ -32,7 +32,7 @@ const useEventCardStyles = makeStyles({
   root: {
     display: 'inline-block',
     boxShadow: 'none',
-    width: '339px',
+    width: '300px',
     height: '161px',
     cursor: 'pointer',
     border: `1px solid ${Colours.BorderLightGray}`,
@@ -86,7 +86,7 @@ const EventCard: EventCard = ({
           </Box>
         </Box>
         <Typography
-          color="textPrimary"
+          color={isActive ? 'textPrimary' : 'textSecondary'}
           variant="h4"
           className={classes.eventTitle}
         >

--- a/src/components/EventOverview/EventsPage.tsx
+++ b/src/components/EventOverview/EventsPage.tsx
@@ -17,7 +17,7 @@ const useStyles = makeStyles({
     minHeight: '100vh',
   },
   topSection: {
-    padding: '56px 56px 0 56px',
+    padding: '35px 64px 0',
     backgroundColor: Colours.White,
   },
   topBar: {
@@ -29,8 +29,8 @@ const useStyles = makeStyles({
   addButton: {
     borderRadius: '2000px',
     position: 'fixed',
-    bottom: '56px',
-    right: '56px',
+    bottom: '38px',
+    right: '64px',
     padding: '12px 26px',
   },
 });
@@ -127,7 +127,14 @@ const EventsPage = () => {
 
   // Filters for inactive or active events
   const filteredEvents = React.useMemo(
-    () => events.filter((event) => event.isActive === (selectedTab === 0)),
+    () =>
+      events
+        .filter((event) => event.isActive === (selectedTab === 0))
+        .sort((a, b) => {
+          const aUpdatedAt = new Date(a.updatedAt);
+          const bUpdatedAt = new Date(b.updatedAt);
+          return bUpdatedAt.getTime() - aUpdatedAt.getTime(); // Sort by recently updated
+        }),
     [events, selectedTab]
   );
 
@@ -144,8 +151,8 @@ const EventsPage = () => {
           tabLabels={tabLabels}
         />
       </Box>
-      <Box padding="70px 56px 168px 56px">
-        <Grid container direction="row" alignItems="center" spacing={3}>
+      <Box padding="53px 51px 114px">
+        <Grid container direction="row" alignItems="center" spacing={1}>
           {filteredEvents.map((event: Event) => (
             <Grid item key={event.id}>
               <EventCard

--- a/src/components/EventOverview/UserProfile.tsx
+++ b/src/components/EventOverview/UserProfile.tsx
@@ -30,10 +30,6 @@ const UserProfile = () => {
     event.stopPropagation();
     history.replace('/manage/members');
   };
-  const handleEditProfileClick = (event) => {
-    event.stopPropagation();
-    // TODO: Redirect to edit profile
-  };
   const handleLogoutClick = (event) => {
     event.stopPropagation();
     // TODO: Logout
@@ -67,7 +63,6 @@ const UserProfile = () => {
           horizontal: 'center',
         }}
       >
-        <MenuItem onClick={handleEditProfileClick}>Edit profile</MenuItem>
         <MenuItem onClick={handleResourceManagementClick}>
           Resource management
         </MenuItem>

--- a/src/graphql/mutations/events.ts
+++ b/src/graphql/mutations/events.ts
@@ -21,6 +21,7 @@ export const ADD_EVENT = gql`
         id
         name
       }
+      updatedAt
     }
   }
 `;
@@ -48,6 +49,7 @@ export const EDIT_EVENT = gql`
         id
         name
       }
+      updatedAt
     }
   }
 `;

--- a/src/graphql/queries/events.ts
+++ b/src/graphql/queries/events.ts
@@ -12,6 +12,7 @@ export interface Event {
   };
   ambulances: Ambulance[];
   hospitals: Hospital[];
+  updatedAt: Date;
 }
 
 export const GET_ALL_EVENTS = gql`
@@ -33,6 +34,7 @@ export const GET_ALL_EVENTS = gql`
         id
         name
       }
+      updatedAt
     }
   }
 `;
@@ -52,6 +54,7 @@ export const GET_EVENT_BY_ID = gql`
         id
         name
       }
+      updatedAt
     }
   }
 `;


### PR DESCRIPTION
[Notion ticket](https://www.notion.so/uwblueprintexecs/Auth-Landing-Clean-up-69ae713e56a1443993822ead17dcd414)

[Figma link](https://www.figma.com/file/IpOPyv79gBwEohvOJvPV6f/%F0%9F%9A%91-Designs-for-Development-(S20%2C-F20)?node-id=1953%3A0)

## Changes
- Fit 3 event cards on a single row (see details in ticket)
- Reduce space for "ADD NEW EVENT" button
- Sort event cards based on last updated (most recently updated events appear first) - based on `updatedAt`
    - For both "Current Events" and "Archived Events"
- Change event title on event card to #676767 (called `"textSecondary"`) for archived events
- Remove "Edit Profile" item from the user dropdown

## Screenshots
![image](https://user-images.githubusercontent.com/22457859/103504515-a55ca200-4e25-11eb-83ea-e577a5ba2608.png)
![image](https://user-images.githubusercontent.com/22457859/103504806-81e62700-4e26-11eb-8093-1cea100774cf.png)
![image](https://user-images.githubusercontent.com/22457859/103504544-bc02f900-4e25-11eb-8976-10c5fc5e2535.png)
![image](https://user-images.githubusercontent.com/22457859/103504718-477c8a00-4e26-11eb-8ace-6b260740b03c.png)

## Testing
- Go to "/events"
- Test with iPad size
- See that 3 event cards fit on a single row
- Edit an event card and see that it's moved to be the first one that's shown
    - Feel free to refresh the page and notice this order is maintained
- Archive an event and see that it's moved to to be the first one shown in the "Archived Events" tab
    - Also notice that all archived event cards have their titles in the colour #676767
    - Feel free to refresh the page and notice this order is maintained
- Click the user dropdown and see that "Edit Profile" is no longer an item

## Checklist
>[Code review doc for reference](https://www.notion.so/uwblueprintexecs/Code-Review-a21fc85b00394f488e92d9d605f6b2bc)

before opening PR
- [x] check notion ticket
- [x] run linter
- [x] go through file diff

filling out PR
- [x] descriptive title
- [x] update `notion ticket` link
- [x] update `figma link`
- [x] fill out `Changes`
  - [ ] \(optional) add inline comments in diff
- [x] fill out `Testing`
- [x] \(optional) add `Screenshots`
- [x] assign yourself to the PR

after opening PR
- [x] link PR to notion ticket
- [x] move ticket to `In PR`
- [x] make sure build passes
- [x] ping `@ps` in `#paramedics-dev`
